### PR TITLE
Fix lit test to have proper string match

### DIFF
--- a/compiler-rt/test/radsan/TestCases/test_radsan.cpp
+++ b/compiler-rt/test/radsan/TestCases/test_radsan.cpp
@@ -11,5 +11,6 @@
 int main() {
   violation();
   return 0;
-  // CHECK: {{.*Intercepted.*}}
+  // CHECK: {{.*Real-time violation.*}}
+  // CHECK: {{.*malloc*}}
 }


### PR DESCRIPTION
This test was failing because of:


```
/Users/topher/code/radsan_cjappl/llvm-project/compiler-rt/test/radsan/TestCases/test_radsan.cpp:14:12: error: CHECK: expected string not found in input
 // CHECK: {{.*Intercepted.*}}
           ^
<stdin>:1:1: note: scanning from here
Real-time violation: intercepted call to real-time unsafe function `malloc` in real-time context! Stack trace:
^
<stdin>:1:19: note: possible intended match here
Real-time violation: intercepted call to real-time unsafe function `malloc` in real-time context! Stack trace

```


Note there is no capital-I "Intercepted" in the output. I changed it to looking for two other strings which are in the output.



To run and confirm this test passes, configure as normal then run:
`ninja check-radsan`. 

Some other tests may fail, but this one does not after this change.