### PR TITLE
Removing interface transitive dependency on <functional>

### DIFF
--- a/compiler-rt/lib/radsan/radsan_context.h
+++ b/compiler-rt/lib/radsan/radsan_context.h
@@ -10,15 +10,10 @@
 
 #include <radsan/radsan_user_interface.h>
 
-#include <functional>
-
 namespace radsan {
 
 class Context {
 public:
-  Context();
-  Context(std::function<OnErrorAction()> get_error_action);
-
   void realtimePush();
   void realtimePop();
 
@@ -34,7 +29,6 @@ private:
 
   int realtime_depth_{0};
   int bypass_depth_{0};
-  std::function<OnErrorAction()> get_error_action_;
 };
 
 Context &getContextForThisThread();

--- a/compiler-rt/lib/radsan/radsan_user_interface.cpp
+++ b/compiler-rt/lib/radsan/radsan_user_interface.cpp
@@ -17,39 +17,33 @@
 
 namespace radsan {
 
-std::function<OnErrorAction()> createErrorActionGetter() {
-  auto const continue_getter = []() { return OnErrorAction::Continue; };
-  auto const exit_getter = []() { return OnErrorAction::ExitWithFailure; };
-  auto const interactive_getter = []() {
+bool ShouldExit() {
+
+  const bool defaultShouldExit = true;
+
+  static const char* user_mode = __sanitizer::GetEnv("RADSAN_ERROR_MODE");
+  if (user_mode == nullptr) {
+    return defaultShouldExit;
+  }
+
+  if (std::strcmp(user_mode, "interactive") == 0) {
     auto response = char{};
 
     std::cout << "Continue? (Y/n): ";
     std::cin >> std::noskipws >> response;
 
-    if (std::toupper(response) == 'N')
-      return OnErrorAction::ExitWithFailure;
-    else
-      return OnErrorAction::Continue;
-  };
-
-  auto user_mode = __sanitizer::GetEnv("RADSAN_ERROR_MODE");
-  if (user_mode == nullptr) {
-    return exit_getter;
-  }
-
-  if (std::strcmp(user_mode, "interactive") == 0) {
-    return interactive_getter;
+    return std::toupper(response) == 'N';
   }
 
   if (std::strcmp(user_mode, "continue") == 0) {
-    return continue_getter;
+    return false;
   }
 
   if (std::strcmp(user_mode, "exit") == 0) {
-    return exit_getter;
+    return true;
   }
 
-  return exit_getter;
+  return defaultShouldExit;
 }
 
 } // namespace radsan

--- a/compiler-rt/lib/radsan/radsan_user_interface.h
+++ b/compiler-rt/lib/radsan/radsan_user_interface.h
@@ -1,14 +1,7 @@
 #pragma once
 
-#include <functional>
-
 namespace radsan {
 
-enum class OnErrorAction {
-    Continue,
-    ExitWithFailure,
-};
+bool ShouldExit();
 
-std::function<OnErrorAction()> createErrorActionGetter();
-
-}
+} // namespace radsan

--- a/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
@@ -68,14 +68,14 @@ TEST(TestRadsanContext,
 }
 
 TEST(TestRadsanContext, onlyDiesIfExitWithFailureReturnedFromUser) {
-  auto fake_action = radsan::OnErrorAction::Continue;
-  auto action_getter = [&fake_action]() { return fake_action; };
 
-  auto context = radsan::Context{action_getter};
+  setenv("RADSAN_ERROR_MODE", "continue", 1);
+
+  auto context = radsan::Context{};
   context.realtimePush();
 
   context.expectNotRealtime("do_some_stuff_expecting_continue");
 
-  fake_action = radsan::OnErrorAction::ExitWithFailure;
+  setenv("RADSAN_ERROR_MODE", "exit", 1);
   EXPECT_DEATH(context.expectNotRealtime("do_some_stuff_expecting_exit"), "");
 }


### PR DESCRIPTION
As mentioned in a very long diatribe on discord, there is another way to guard against the inclusion of `aligned_alloc`, one that they recommend and have done in tsan. 

That can be seen here:

lib/tsan/rtl/tsan_interceptors_libdispatch.cpp
```cpp
// dispatch_async_and_wait() and friends were introduced in macOS 10.14.
// Linking of these interceptors fails when using an older SDK.
#if !SANITIZER_APPLE || defined(__MAC_10_14)
// macOS 10.14 is greater than our minimal deployment target.  To ensure we
// generate a weak reference so the TSan dylib continues to work on older
// systems, we need to forward declare the intercepted functions as "weak
// imports".   Note that this file is multi-platform, so we cannot include the
// actual header file (#include <dispatch/dispatch.h>).
SANITIZER_WEAK_IMPORT void dispatch_async_and_wait(
    dispatch_queue_t queue, DISPATCH_NOESCAPE dispatch_block_t block);
SANITIZER_WEAK_IMPORT void dispatch_async_and_wait_f(
    dispatch_queue_t queue, void *context, dispatch_function_t work);
SANITIZER_WEAK_IMPORT void dispatch_barrier_async_and_wait(
    dispatch_queue_t queue, DISPATCH_NOESCAPE dispatch_block_t block);
SANITIZER_WEAK_IMPORT void dispatch_barrier_async_and_wait_f(
    dispatch_queue_t queue, void *context, dispatch_function_t work);

DISPATCH_INTERCEPT_SYNC_F(dispatch_async_and_wait_f, false)
DISPATCH_INTERCEPT_SYNC_B(dispatch_async_and_wait, false)
DISPATCH_INTERCEPT_SYNC_F(dispatch_barrier_async_and_wait_f, true)
DISPATCH_INTERCEPT_SYNC_B(dispatch_barrier_async_and_wait, true)
#endif
```

It can be summarized by "Weakly forward declare the thing you wish to intercept, and you can intercept it even if you compile on an older OS. Running on older OS will not crash or have issues here, because they will never be able to call this function".


I attempted to do that, but was running into an issue where the `aligned_alloc` was still unable to compile. This is due to a transitive dependency that brought in the REAL `aligned_alloc` before my faker forward declared one:

```
In file included from /Users/topher/code/radsan_cjappl/llvm-project/compiler-rt/lib/radsan/radsan_interceptors.cpp:17:
In file included from /Users/topher/code/radsan_cjappl/llvm-project/compiler-rt/lib/radsan/../radsan/radsan_context.h:11:
In file included from /Users/topher/code/radsan_cjappl/llvm-project/compiler-rt/lib/radsan/../radsan/radsan_user_interface.h:3:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/functional:503:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/search.h:14:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/iterator_operations.h:15:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__iterator/advance.h:26:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/cstdlib:87:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/stdlib.h:94:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/stdlib.h:128:
``` 

If we can remove our dependency on `functional` we can simplify this and do our `aligned_alloc` in the same way that TSAN does (recommended by an employee from Apple apparently on the LLVM sanitizers team).