### PR TITLE
Add all read/write functions to the interceptors list

### DIFF
--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -107,6 +107,20 @@ INTERCEPTOR(ssize_t, read, int fd, void *buf, size_t count) {
   return REAL(read)(fd, buf, count);
 }
 
+#if SANITIZER_APPLE
+INTERCEPTOR(ssize_t, pread, int fd, void *buf, size_t count, off_t offset) {
+  radsan::expectNotRealtime("pread");
+  return REAL(pread)(fd, buf, count, offset);
+}
+
+INTERCEPTOR(ssize_t, readv, int fd, const struct iovec *iov, int iovcnt) {
+  radsan::expectNotRealtime("readv");
+  return REAL(readv)(fd, iov, iovcnt);
+}
+#endif
+
+
+
 INTERCEPTOR(size_t, fwrite, const void *ptr, size_t size, size_t nitems,
             FILE *stream) {
   radsan::expectNotRealtime("fwrite");
@@ -384,6 +398,8 @@ void initialiseInterceptors() {
 #if SANITIZER_APPLE
   INTERCEPT_FUNCTION(OSSpinLockLock);
   INTERCEPT_FUNCTION(os_unfair_lock_lock);
+  INTERCEPT_FUNCTION(pread);
+  INTERCEPT_FUNCTION(readv);
 #elif SANITIZER_LINUX
   INTERCEPT_FUNCTION(pthread_spin_lock);
 #endif

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -107,6 +107,12 @@ INTERCEPTOR(ssize_t, read, int fd, void *buf, size_t count) {
   return REAL(read)(fd, buf, count);
 }
 
+// intercept write
+INTERCEPTOR(ssize_t, write, int fd, const void *buf, size_t count) {
+  radsan::expectNotRealtime("write");
+  return REAL(write)(fd, buf, count);
+}
+
 #if SANITIZER_APPLE
 INTERCEPTOR(ssize_t, pread, int fd, void *buf, size_t count, off_t offset) {
   radsan::expectNotRealtime("pread");
@@ -117,8 +123,19 @@ INTERCEPTOR(ssize_t, readv, int fd, const struct iovec *iov, int iovcnt) {
   radsan::expectNotRealtime("readv");
   return REAL(readv)(fd, iov, iovcnt);
 }
-#endif
 
+INTERCEPTOR(ssize_t, pwrite, int fd, const void *buf, size_t count,
+            off_t offset) {
+  radsan::expectNotRealtime("pwrite");
+  return REAL(pwrite)(fd, buf, count, offset);
+}
+
+INTERCEPTOR(ssize_t, writev, int fd, const struct iovec *iov, int iovcnt) {
+  radsan::expectNotRealtime("writev");
+  return REAL(writev)(fd, iov, iovcnt);
+}
+
+#endif
 
 
 INTERCEPTOR(size_t, fwrite, const void *ptr, size_t size, size_t nitems,

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -102,6 +102,11 @@ INTERCEPTOR(size_t, fread, void *ptr, size_t size, size_t nitems,
   return REAL(fread)(ptr, size, nitems, stream);
 }
 
+INTERCEPTOR(ssize_t, read, int fd, void *buf, size_t count) {
+  radsan::expectNotRealtime("read");
+  return REAL(read)(fd, buf, count);
+}
+
 INTERCEPTOR(size_t, fwrite, const void *ptr, size_t size, size_t nitems,
             FILE *stream) {
   radsan::expectNotRealtime("fwrite");
@@ -368,6 +373,7 @@ void initialiseInterceptors() {
   INTERCEPT_FUNCTION(close);
   INTERCEPT_FUNCTION(fopen);
   INTERCEPT_FUNCTION(fread);
+  INTERCEPT_FUNCTION(read);
   INTERCEPT_FUNCTION(fwrite);
   INTERCEPT_FUNCTION(fclose);
   INTERCEPT_FUNCTION(fcntl);

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -135,8 +135,7 @@ INTERCEPTOR(ssize_t, writev, int fd, const struct iovec *iov, int iovcnt) {
   return REAL(writev)(fd, iov, iovcnt);
 }
 
-#endif
-
+#endif // SANITIZER_APPLE
 
 INTERCEPTOR(size_t, fwrite, const void *ptr, size_t size, size_t nitems,
             FILE *stream) {
@@ -405,6 +404,14 @@ void initialiseInterceptors() {
   INTERCEPT_FUNCTION(fopen);
   INTERCEPT_FUNCTION(fread);
   INTERCEPT_FUNCTION(read);
+  INTERCEPT_FUNCTION(write);
+#if SANITIZER_APPLE
+  INTERCEPT_FUNCTION(pread);
+  INTERCEPT_FUNCTION(readv);
+  INTERCEPT_FUNCTION(pwrite);
+  INTERCEPT_FUNCTION(writev);
+#endif
+
   INTERCEPT_FUNCTION(fwrite);
   INTERCEPT_FUNCTION(fclose);
   INTERCEPT_FUNCTION(fcntl);
@@ -415,8 +422,6 @@ void initialiseInterceptors() {
 #if SANITIZER_APPLE
   INTERCEPT_FUNCTION(OSSpinLockLock);
   INTERCEPT_FUNCTION(os_unfair_lock_lock);
-  INTERCEPT_FUNCTION(pread);
-  INTERCEPT_FUNCTION(readv);
 #elif SANITIZER_LINUX
   INTERCEPT_FUNCTION(pthread_spin_lock);
 #endif

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -239,6 +239,71 @@ TEST(TestRadsanInterceptors, readDiesWhenRealtime) {
   std::remove(temporary_file_path());
 }
 
+TEST(TestRadsanInterceptors, writeDiesWhenRealtime) {
+  auto fd = open(temporary_file_path(), O_WRONLY);
+  auto func = [fd]() {
+    char c{};
+    write(fd, &c, 1);
+  };
+  expectRealtimeDeath(func, "write");
+  expectNonrealtimeSurvival(func);
+  close(fd);
+  std::remove(temporary_file_path());
+}
+
+#if SANITIZER_APPLE
+TEST(TestRadsanInterceptors, preadDiesWhenRealtime) {
+  auto fd = open(temporary_file_path(), O_RDONLY);
+  auto func = [fd]() {
+    char c{};
+    pread(fd, &c, 1, 0);
+  };
+  expectRealtimeDeath(func, "pread");
+  expectNonrealtimeSurvival(func);
+  close(fd);
+  std::remove(temporary_file_path());
+}
+
+TEST(TestRadsanInterceptors, readvDiesWhenRealtime) {
+  auto fd = open(temporary_file_path(), O_RDONLY);
+  auto func = [fd]() {
+    char c{};
+    iovec iov = {&c, 1};
+    readv(fd, &iov, 1);
+  };
+  expectRealtimeDeath(func, "readv");
+  expectNonrealtimeSurvival(func);
+  close(fd);
+  std::remove(temporary_file_path());
+}
+
+TEST(TestRadsanInterceptors, pwriteDiesWhenRealtime) {
+  auto fd = open(temporary_file_path(), O_WRONLY);
+  auto func = [fd]() {
+    char c{};
+    pwrite(fd, &c, 1, 0);
+  };
+  expectRealtimeDeath(func, "pwrite");
+  expectNonrealtimeSurvival(func);
+  close(fd);
+  std::remove(temporary_file_path());
+}
+
+TEST(TestRadsanInterceptors, writevDiesWhenRealtime) {
+  auto fd = open(temporary_file_path(), O_WRONLY);
+  auto func = [fd]() {
+    char c{};
+    iovec iov = {&c, 1};
+    writev(fd, &iov, 1);
+  };
+  expectRealtimeDeath(func, "writev");
+  expectNonrealtimeSurvival(func);
+  close(fd);
+  std::remove(temporary_file_path());
+}
+
+#endif // SANITIZER_APPLE
+
 TEST(TestRadsanInterceptors, fwriteDiesWhenRealtime) {
   auto fd = fopen(temporary_file_path(), "w");
   ASSERT_NE(nullptr, fd);
@@ -344,30 +409,6 @@ TEST(TestRadsanInterceptors, osUnfairLockLockDiesWhenRealtime) {
   expectNonrealtimeSurvival(func);
 }
 
-TEST(TestRadsanInterceptors, preadDiesWhenRealtime) {
-  auto fd = open(temporary_file_path(), O_RDONLY);
-  auto func = [fd]() {
-    char c{};
-    pread(fd, &c, 1, 0);
-  };
-  expectRealtimeDeath(func, "pread");
-  expectNonrealtimeSurvival(func);
-  close(fd);
-  std::remove(temporary_file_path());
-}
-
-TEST(TestRadsanInterceptors, readvDiesWhenRealtime) {
-  auto fd = open(temporary_file_path(), O_RDONLY);
-  auto func = [fd]() {
-    char c{};
-    iovec iov = {&c, 1};
-    readv(fd, &iov, 1);
-  };
-  expectRealtimeDeath(func, "readv");
-  expectNonrealtimeSurvival(func);
-  close(fd);
-  std::remove(temporary_file_path());
-}
 #endif // SANITIZER_APPLE
 
 #if SANITIZER_LINUX

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -225,7 +225,7 @@ TEST(TestRadsanInterceptors, freadDiesWhenRealtime) {
   std::remove(temporary_file_path());
 }
 
-class FileTestFixture : public ::testing::Test {
+class FdFixture : public ::testing::Test {
 protected:
   int fd = -1; 
 
@@ -243,7 +243,7 @@ protected:
   }
 };
 
-TEST_F(FileTestFixture, readDiesWhenRealtime) {
+TEST_F(FdFixture, readDiesWhenRealtime) {
   auto func = [this]() {
     char c{};
     read(fd, &c, 1);
@@ -252,7 +252,7 @@ TEST_F(FileTestFixture, readDiesWhenRealtime) {
   expectNonrealtimeSurvival(func);
 }
 
-TEST_F(FileTestFixture, writeDiesWhenRealtime) {
+TEST_F(FdFixture, writeDiesWhenRealtime) {
   auto func = [this]() {
     char c{};
     write(fd, &c, 1);
@@ -262,7 +262,7 @@ TEST_F(FileTestFixture, writeDiesWhenRealtime) {
 }
 
 #if SANITIZER_APPLE
-TEST_F(FileTestFixture, preadDiesWhenRealtime) {
+TEST_F(FdFixture, preadDiesWhenRealtime) {
   auto func = [this]() {
       char c{};
       pread(fd, &c, 1, 0);
@@ -271,7 +271,7 @@ TEST_F(FileTestFixture, preadDiesWhenRealtime) {
   expectNonrealtimeSurvival(func);
 }
 
-TEST_F(FileTestFixture, readvDiesWhenRealtime) {
+TEST_F(FdFixture, readvDiesWhenRealtime) {
     auto func = [this]() {
         char c{};
         iovec iov = {&c, 1};
@@ -281,7 +281,7 @@ TEST_F(FileTestFixture, readvDiesWhenRealtime) {
     expectNonrealtimeSurvival(func);
 }
 
-TEST_F(FileTestFixture, pwriteDiesWhenRealtime) {
+TEST_F(FdFixture, pwriteDiesWhenRealtime) {
     auto func = [this]() {
         char c{};
         pwrite(fd, &c, 1, 0);
@@ -290,7 +290,7 @@ TEST_F(FileTestFixture, pwriteDiesWhenRealtime) {
     expectNonrealtimeSurvival(func);
 }
 
-TEST_F(FileTestFixture, writevDiesWhenRealtime) {
+TEST_F(FdFixture, writevDiesWhenRealtime) {
     auto func = [this]() {
         char c{};
         iovec iov = {&c, 1};

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -227,6 +227,7 @@ TEST(TestRadsanInterceptors, freadDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, readDiesWhenRealtime) {
   auto fd = open(temporary_file_path(), O_RDONLY);
+  EXPECT_THAT(fd, Ne(-1));
   auto func = [fd]() {
     char c{};
     read(fd, &c, 1);
@@ -241,6 +242,7 @@ TEST(TestRadsanInterceptors, readDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, writeDiesWhenRealtime) {
   auto fd = open(temporary_file_path(), O_WRONLY);
+  EXPECT_THAT(fd, Ne(-1));
   auto func = [fd]() {
     char c{};
     write(fd, &c, 1);


### PR DESCRIPTION
Adds all read and write variants to the interceptors list

closes https://github.com/realtime-sanitizer/radsan/issues/28
