### PR TITLE
Conform to LLVM style guide

### DIFF
--- a/compiler-rt/lib/radsan/radsan.cpp
+++ b/compiler-rt/lib/radsan/radsan.cpp
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan.cpp - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #include <radsan/radsan.h>
 #include <radsan/radsan_context.h>

--- a/compiler-rt/lib/radsan/radsan.cpp
+++ b/compiler-rt/lib/radsan/radsan.cpp
@@ -12,21 +12,21 @@
 #include <unistd.h>
 
 extern "C" {
-RADSAN_EXPORT void radsan_init() { radsan::initialiseInterceptors(); }
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_init() { radsan::InitializeInterceptors(); }
 
-RADSAN_EXPORT void radsan_realtime_enter() {
-  radsan::getContextForThisThread().RealtimePush();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_enter() {
+  radsan::GetContextForThisThread().RealtimePush();
 }
 
-RADSAN_EXPORT void radsan_realtime_exit() {
-  radsan::getContextForThisThread().RealtimePop();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_exit() {
+  radsan::GetContextForThisThread().RealtimePop();
 }
 
-RADSAN_EXPORT void radsan_off() {
-  radsan::getContextForThisThread().BypassPush();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_off() {
+  radsan::GetContextForThisThread().BypassPush();
 }
 
-RADSAN_EXPORT void radsan_on() {
-  radsan::getContextForThisThread().BypassPop();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_on() {
+  radsan::GetContextForThisThread().BypassPop();
 }
 }

--- a/compiler-rt/lib/radsan/radsan.cpp
+++ b/compiler-rt/lib/radsan/radsan.cpp
@@ -12,7 +12,10 @@
 #include <unistd.h>
 
 extern "C" {
-SANITIZER_INTERFACE_ATTRIBUTE void radsan_init() { radsan::InitializeInterceptors(); }
+
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_init() { 
+  radsan::InitializeInterceptors(); 
+}
 
 SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_enter() {
   radsan::GetContextForThisThread().RealtimePush();
@@ -29,4 +32,5 @@ SANITIZER_INTERFACE_ATTRIBUTE void radsan_off() {
 SANITIZER_INTERFACE_ATTRIBUTE void radsan_on() {
   radsan::GetContextForThisThread().BypassPop();
 }
-}
+
+} // extern "C"

--- a/compiler-rt/lib/radsan/radsan.cpp
+++ b/compiler-rt/lib/radsan/radsan.cpp
@@ -15,18 +15,18 @@ extern "C" {
 RADSAN_EXPORT void radsan_init() { radsan::initialiseInterceptors(); }
 
 RADSAN_EXPORT void radsan_realtime_enter() {
-  radsan::getContextForThisThread().realtimePush();
+  radsan::getContextForThisThread().RealtimePush();
 }
 
 RADSAN_EXPORT void radsan_realtime_exit() {
-  radsan::getContextForThisThread().realtimePop();
+  radsan::getContextForThisThread().RealtimePop();
 }
 
 RADSAN_EXPORT void radsan_off() {
-  radsan::getContextForThisThread().bypassPush();
+  radsan::getContextForThisThread().BypassPush();
 }
 
 RADSAN_EXPORT void radsan_on() {
-  radsan::getContextForThisThread().bypassPop();
+  radsan::getContextForThisThread().BypassPop();
 }
 }

--- a/compiler-rt/lib/radsan/radsan.h
+++ b/compiler-rt/lib/radsan/radsan.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#define RADSAN_EXPORT __attribute__((visibility("default")))
+#include "sanitizer_common/sanitizer_internal_defs.h"
 
 extern "C" {
 
@@ -18,7 +18,7 @@ extern "C" {
 
     @warning Do not call this method as a user.
 */
-RADSAN_EXPORT void radsan_init();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_init();
 
 /** Enter real-time context.
 
@@ -28,7 +28,7 @@ RADSAN_EXPORT void radsan_init();
 
     @warning Do not call this method as a user
 */
-RADSAN_EXPORT void radsan_realtime_enter();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_enter();
 
 /** Exit the real-time context.
 
@@ -37,7 +37,7 @@ RADSAN_EXPORT void radsan_realtime_enter();
 
     @warning Do not call this method as a user
 */
-RADSAN_EXPORT void radsan_realtime_exit();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_exit();
 
 /** Disable all RADSan error reporting.
 
@@ -62,12 +62,12 @@ RADSAN_EXPORT void radsan_realtime_exit();
         }
 
 */
-RADSAN_EXPORT void radsan_off();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_off();
 
 /** Re-enable all RADSan error reporting.
 
     The counterpart to `radsan_off`. See the description for `radsan_off` for
     details about how to use this method.
 */
-RADSAN_EXPORT void radsan_on();
+SANITIZER_INTERFACE_ATTRIBUTE void radsan_on();
 }

--- a/compiler-rt/lib/radsan/radsan.h
+++ b/compiler-rt/lib/radsan/radsan.h
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan.h - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 
@@ -52,7 +54,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void radsan_realtime_exit();
 
     Example:
 
-        [[clang::realtime]] float process (float x)
+        float process (float x) [[clang::nonblocking]] 
         {
             auto const y = 2.0f * x;
 

--- a/compiler-rt/lib/radsan/radsan.h
+++ b/compiler-rt/lib/radsan/radsan.h
@@ -70,4 +70,5 @@ SANITIZER_INTERFACE_ATTRIBUTE void radsan_off();
     details about how to use this method.
 */
 SANITIZER_INTERFACE_ATTRIBUTE void radsan_on();
-}
+
+} // extern "C"

--- a/compiler-rt/lib/radsan/radsan_context.cpp
+++ b/compiler-rt/lib/radsan/radsan_context.cpp
@@ -22,9 +22,9 @@ using namespace __sanitizer;
 
 namespace detail {
 
-static pthread_key_t key;
-static pthread_once_t key_once = PTHREAD_ONCE_INIT;
-void internalFree(void *ptr) { InternalFree(ptr); }
+static pthread_key_t Key;
+static pthread_once_t KeyOnce = PTHREAD_ONCE_INIT;
+void internalFree(void *Ptr) { __sanitizer::InternalFree(Ptr); }
 
 } // namespace detail
 
@@ -32,49 +32,49 @@ namespace radsan {
 
 Context::Context() = default;
 
-void Context::realtimePush() { realtime_depth_++; }
+void Context::RealtimePush() { RealtimeDepth++; }
 
-void Context::realtimePop() { realtime_depth_--; }
+void Context::RealtimePop() { RealtimeDepth--; }
 
-void Context::bypassPush() { bypass_depth_++; }
+void Context::BypassPush() { BypassDepth++; }
 
-void Context::bypassPop() { bypass_depth_--; }
+void Context::BypassPop() { BypassDepth--; }
 
-void Context::expectNotRealtime(const char *intercepted_function_name) {
-  if (inRealtimeContext() && !isBypassed()) {
-    bypassPush();
-    printDiagnostics(intercepted_function_name);
+void Context::ExpectNotRealtime(const char *InterceptedFunctionName) {
+  if (InRealtimeContext() && !IsBypassed()) {
+    BypassPush();
+    PrintDiagnostics(InterceptedFunctionName);
     exit(EXIT_FAILURE);
-    bypassPop();
+    BypassPop();
   }
 }
 
-bool Context::inRealtimeContext() const { return realtime_depth_ > 0; }
+bool Context::InRealtimeContext() const { return RealtimeDepth > 0; }
 
-bool Context::isBypassed() const { return bypass_depth_ > 0; }
+bool Context::IsBypassed() const { return BypassDepth > 0; }
 
-void Context::printDiagnostics(const char *intercepted_function_name) {
+void Context::PrintDiagnostics(const char *InterceptedFunctionName) {
   fprintf(stderr,
           "Real-time violation: intercepted call to real-time unsafe function "
           "`%s` in real-time context! Stack trace:\n",
-          intercepted_function_name);
+          InterceptedFunctionName);
   radsan::printStackTrace();
 }
 
 Context &getContextForThisThread() {
-  auto make_tls_key = []() {
-    CHECK_EQ(pthread_key_create(&detail::key, detail::internalFree), 0);
+  auto MakeTlsKey = []() {
+    CHECK_EQ(pthread_key_create(&detail::Key, detail::internalFree), 0);
   };
 
-  pthread_once(&detail::key_once, make_tls_key);
-  auto *ptr = static_cast<Context *>(pthread_getspecific(detail::key));
-  if (ptr == nullptr) {
-    ptr = static_cast<Context *>(InternalAlloc(sizeof(Context)));
-    new(ptr) Context();
-    pthread_setspecific(detail::key, ptr);
+  pthread_once(&detail::KeyOnce, MakeTlsKey);
+  Context *CurrentThreadContext = static_cast<Context *>(pthread_getspecific(detail::Key));
+  if (CurrentThreadContext == nullptr) {
+    CurrentThreadContext = static_cast<Context *>(InternalAlloc(sizeof(Context)));
+    new(CurrentThreadContext) Context();
+    pthread_setspecific(detail::Key, CurrentThreadContext);
   }
 
-  return *ptr;
+  return *CurrentThreadContext;
 }
 
 } // namespace radsan

--- a/compiler-rt/lib/radsan/radsan_context.cpp
+++ b/compiler-rt/lib/radsan/radsan_context.cpp
@@ -58,10 +58,10 @@ void Context::PrintDiagnostics(const char *InterceptedFunctionName) {
           "Real-time violation: intercepted call to real-time unsafe function "
           "`%s` in real-time context! Stack trace:\n",
           InterceptedFunctionName);
-  radsan::printStackTrace();
+  radsan::PrintStackTrace();
 }
 
-Context &getContextForThisThread() {
+Context &GetContextForThisThread() {
   auto MakeTlsKey = []() {
     CHECK_EQ(pthread_key_create(&detail::Key, detail::internalFree), 0);
   };

--- a/compiler-rt/lib/radsan/radsan_context.cpp
+++ b/compiler-rt/lib/radsan/radsan_context.cpp
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_context.cpp - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #include <radsan/radsan_context.h>
 

--- a/compiler-rt/lib/radsan/radsan_context.h
+++ b/compiler-rt/lib/radsan/radsan_context.h
@@ -20,7 +20,7 @@ public:
   void BypassPush();
   void BypassPop();
 
-  void ExpectNotRealtime(const char *interpreted_function_name);
+  void ExpectNotRealtime(const char *InterceptedFunctionName);
 
 private:
   bool InRealtimeContext() const;

--- a/compiler-rt/lib/radsan/radsan_context.h
+++ b/compiler-rt/lib/radsan/radsan_context.h
@@ -31,6 +31,6 @@ private:
   int BypassDepth{0};
 };
 
-Context &getContextForThisThread();
+Context &GetContextForThisThread();
 
 } // namespace radsan

--- a/compiler-rt/lib/radsan/radsan_context.h
+++ b/compiler-rt/lib/radsan/radsan_context.h
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_context.h - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/compiler-rt/lib/radsan/radsan_context.h
+++ b/compiler-rt/lib/radsan/radsan_context.h
@@ -14,21 +14,21 @@ class Context {
 public:
   Context();
 
-  void realtimePush();
-  void realtimePop();
+  void RealtimePush();
+  void RealtimePop();
 
-  void bypassPush();
-  void bypassPop();
+  void BypassPush();
+  void BypassPop();
 
-  void expectNotRealtime(const char *interpreted_function_name);
+  void ExpectNotRealtime(const char *interpreted_function_name);
 
 private:
-  bool inRealtimeContext() const;
-  bool isBypassed() const;
-  void printDiagnostics(const char *intercepted_function_name);
+  bool InRealtimeContext() const;
+  bool IsBypassed() const;
+  void PrintDiagnostics(const char *InterceptedFunctionName);
 
-  int realtime_depth_{0};
-  int bypass_depth_{0};
+  int RealtimeDepth{0};
+  int BypassDepth{0};
 };
 
 Context &getContextForThisThread();

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -38,8 +38,8 @@
 using namespace __sanitizer;
 
 namespace radsan {
-void expectNotRealtime(const char *intercepted_function_name) {
-  getContextForThisThread().expectNotRealtime(intercepted_function_name);
+void ExpectNotRealtime(const char *InterceptedFunctionName) {
+  getContextForThisThread().ExpectNotRealtime(InterceptedFunctionName);
 }
 } // namespace radsan
 
@@ -50,7 +50,7 @@ void expectNotRealtime(const char *intercepted_function_name) {
 INTERCEPTOR(int, open, const char *path, int oflag, ...) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
-  radsan::expectNotRealtime("open");
+  radsan::ExpectNotRealtime("open");
   va_list args;
   va_start(args, oflag);
   const int result = REAL(open)(path, oflag, args);
@@ -61,7 +61,7 @@ INTERCEPTOR(int, open, const char *path, int oflag, ...) {
 INTERCEPTOR(int, openat, int fd, const char *path, int oflag, ...) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
-  radsan::expectNotRealtime("openat");
+  radsan::ExpectNotRealtime("openat");
   va_list args;
   va_start(args, oflag);
   const int result = REAL(openat)(fd, path, oflag, args);
@@ -72,13 +72,13 @@ INTERCEPTOR(int, openat, int fd, const char *path, int oflag, ...) {
 INTERCEPTOR(int, creat, const char *path, mode_t mode) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
-  radsan::expectNotRealtime("creat");
+  radsan::ExpectNotRealtime("creat");
   const int result = REAL(creat)(path, mode);
   return result;
 }
 
 INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
-  radsan::expectNotRealtime("fcntl");
+  radsan::ExpectNotRealtime("fcntl");
   va_list args;
   va_start(args, cmd);
   const int result = REAL(fcntl)(filedes, cmd, args);
@@ -87,34 +87,34 @@ INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
 }
 
 INTERCEPTOR(int, close, int filedes) {
-  radsan::expectNotRealtime("close");
+  radsan::ExpectNotRealtime("close");
   return REAL(close)(filedes);
 }
 
 INTERCEPTOR(FILE *, fopen, const char *path, const char *mode) {
-  radsan::expectNotRealtime("fopen");
+  radsan::ExpectNotRealtime("fopen");
   return REAL(fopen)(path, mode);
 }
 
 INTERCEPTOR(size_t, fread, void *ptr, size_t size, size_t nitems,
             FILE *stream) {
-  radsan::expectNotRealtime("fread");
+  radsan::ExpectNotRealtime("fread");
   return REAL(fread)(ptr, size, nitems, stream);
 }
 
 INTERCEPTOR(size_t, fwrite, const void *ptr, size_t size, size_t nitems,
             FILE *stream) {
-  radsan::expectNotRealtime("fwrite");
+  radsan::ExpectNotRealtime("fwrite");
   return REAL(fwrite)(ptr, size, nitems, stream);
 }
 
 INTERCEPTOR(int, fclose, FILE *stream) {
-  radsan::expectNotRealtime("fclose");
+  radsan::ExpectNotRealtime("fclose");
   return REAL(fclose)(stream);
 }
 
 INTERCEPTOR(int, fputs, const char *s, FILE *stream) {
-  radsan::expectNotRealtime("fputs");
+  radsan::ExpectNotRealtime("fputs");
   return REAL(fputs)(s, stream);
 }
 
@@ -123,7 +123,7 @@ INTERCEPTOR(int, fputs, const char *s, FILE *stream) {
 */
 
 INTERCEPTOR(int, puts, const char *s) {
-  radsan::expectNotRealtime("puts");
+  radsan::ExpectNotRealtime("puts");
   return REAL(puts)(s);
 }
 
@@ -136,77 +136,77 @@ INTERCEPTOR(int, puts, const char *s) {
 // OSSpinLockLock is deprecated, but still in use in libc++
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 INTERCEPTOR(void, OSSpinLockLock, volatile OSSpinLock *lock) {
-  radsan::expectNotRealtime("OSSpinLockLock");
+  radsan::ExpectNotRealtime("OSSpinLockLock");
   return REAL(OSSpinLockLock)(lock);
 }
 #pragma clang diagnostic pop
 
 INTERCEPTOR(void, os_unfair_lock_lock, os_unfair_lock_t lock) {
-  radsan::expectNotRealtime("os_unfair_lock_lock");
+  radsan::ExpectNotRealtime("os_unfair_lock_lock");
   return REAL(os_unfair_lock_lock)(lock);
 }
 #elif SANITIZER_LINUX
 INTERCEPTOR(int, pthread_spin_lock, pthread_spinlock_t *spinlock) {
-  radsan::expectNotRealtime("pthread_spin_lock");
+  radsan::ExpectNotRealtime("pthread_spin_lock");
   return REAL(pthread_spin_lock)(spinlock);
 }
 #endif
 
 INTERCEPTOR(int, pthread_create, pthread_t *thread, const pthread_attr_t *attr,
             void *(*start_routine)(void *), void *arg) {
-  radsan::expectNotRealtime("pthread_create");
+  radsan::ExpectNotRealtime("pthread_create");
   return REAL(pthread_create)(thread, attr, start_routine, arg);
 }
 
 INTERCEPTOR(int, pthread_mutex_lock, pthread_mutex_t *mutex) {
-  radsan::expectNotRealtime("pthread_mutex_lock");
+  radsan::ExpectNotRealtime("pthread_mutex_lock");
   return REAL(pthread_mutex_lock)(mutex);
 }
 
 INTERCEPTOR(int, pthread_mutex_unlock, pthread_mutex_t *mutex) {
-  radsan::expectNotRealtime("pthread_mutex_unlock");
+  radsan::ExpectNotRealtime("pthread_mutex_unlock");
   return REAL(pthread_mutex_unlock)(mutex);
 }
 
 INTERCEPTOR(int, pthread_join, pthread_t thread, void **value_ptr) {
-  radsan::expectNotRealtime("pthread_join");
+  radsan::ExpectNotRealtime("pthread_join");
   return REAL(pthread_join)(thread, value_ptr);
 }
 
 INTERCEPTOR(int, pthread_cond_signal, pthread_cond_t *cond) {
-  radsan::expectNotRealtime("pthread_cond_signal");
+  radsan::ExpectNotRealtime("pthread_cond_signal");
   return REAL(pthread_cond_signal)(cond);
 }
 
 INTERCEPTOR(int, pthread_cond_broadcast, pthread_cond_t *cond) {
-  radsan::expectNotRealtime("pthread_cond_broadcast");
+  radsan::ExpectNotRealtime("pthread_cond_broadcast");
   return REAL(pthread_cond_broadcast)(cond);
 }
 
 INTERCEPTOR(int, pthread_cond_wait, pthread_cond_t *cond,
             pthread_mutex_t *mutex) {
-  radsan::expectNotRealtime("pthread_cond_wait");
+  radsan::ExpectNotRealtime("pthread_cond_wait");
   return REAL(pthread_cond_wait)(cond, mutex);
 }
 
 INTERCEPTOR(int, pthread_cond_timedwait, pthread_cond_t *cond,
             pthread_mutex_t *mutex, const timespec *ts) {
-  radsan::expectNotRealtime("pthread_cond_timedwait");
+  radsan::ExpectNotRealtime("pthread_cond_timedwait");
   return REAL(pthread_cond_timedwait)(cond, mutex, ts);
 }
 
 INTERCEPTOR(int, pthread_rwlock_rdlock, pthread_rwlock_t *lock) {
-  radsan::expectNotRealtime("pthread_rwlock_rdlock");
+  radsan::ExpectNotRealtime("pthread_rwlock_rdlock");
   return REAL(pthread_rwlock_rdlock)(lock);
 }
 
 INTERCEPTOR(int, pthread_rwlock_unlock, pthread_rwlock_t *lock) {
-  radsan::expectNotRealtime("pthread_rwlock_unlock");
+  radsan::ExpectNotRealtime("pthread_rwlock_unlock");
   return REAL(pthread_rwlock_unlock)(lock);
 }
 
 INTERCEPTOR(int, pthread_rwlock_wrlock, pthread_rwlock_t *lock) {
-  radsan::expectNotRealtime("pthread_rwlock_wrlock");
+  radsan::ExpectNotRealtime("pthread_rwlock_wrlock");
   return REAL(pthread_rwlock_wrlock)(lock);
 }
 
@@ -215,18 +215,18 @@ INTERCEPTOR(int, pthread_rwlock_wrlock, pthread_rwlock_t *lock) {
 */
 
 INTERCEPTOR(unsigned int, sleep, unsigned int s) {
-  radsan::expectNotRealtime("sleep");
+  radsan::ExpectNotRealtime("sleep");
   return REAL(sleep)(s);
 }
 
 INTERCEPTOR(int, usleep, useconds_t u) {
-  radsan::expectNotRealtime("usleep");
+  radsan::ExpectNotRealtime("usleep");
   return REAL(usleep)(u);
 }
 
 INTERCEPTOR(int, nanosleep, const struct timespec *rqtp,
             struct timespec *rmtp) {
-  radsan::expectNotRealtime("nanosleep");
+  radsan::ExpectNotRealtime("nanosleep");
   return REAL(nanosleep)(rqtp, rmtp);
 }
 
@@ -235,40 +235,40 @@ INTERCEPTOR(int, nanosleep, const struct timespec *rqtp,
 */
 
 INTERCEPTOR(void *, calloc, SIZE_T num, SIZE_T size) {
-  radsan::expectNotRealtime("calloc");
+  radsan::ExpectNotRealtime("calloc");
   return REAL(calloc)(num, size);
 }
 
 INTERCEPTOR(void, free, void *ptr) {
   if (ptr != NULL) {
-    radsan::expectNotRealtime("free");
+    radsan::ExpectNotRealtime("free");
   }
   return REAL(free)(ptr);
 }
 
 INTERCEPTOR(void *, malloc, SIZE_T size) {
-  radsan::expectNotRealtime("malloc");
+  radsan::ExpectNotRealtime("malloc");
   return REAL(malloc)(size);
 }
 
 INTERCEPTOR(void *, realloc, void *ptr, SIZE_T size) {
-  radsan::expectNotRealtime("realloc");
+  radsan::ExpectNotRealtime("realloc");
   return REAL(realloc)(ptr, size);
 }
 
 INTERCEPTOR(void *, reallocf, void *ptr, SIZE_T size) {
-  radsan::expectNotRealtime("reallocf");
+  radsan::ExpectNotRealtime("reallocf");
   return REAL(reallocf)(ptr, size);
 }
 
 INTERCEPTOR(void *, valloc, SIZE_T size) {
-  radsan::expectNotRealtime("valloc");
+  radsan::ExpectNotRealtime("valloc");
   return REAL(valloc)(size);
 }
 
 #if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 INTERCEPTOR(void *, aligned_alloc, SIZE_T alignment, SIZE_T size) {
-  radsan::expectNotRealtime("aligned_alloc");
+  radsan::ExpectNotRealtime("aligned_alloc");
   return REAL(aligned_alloc)(alignment, size);
 }
 #define RADSAN_MAYBE_INTERCEPT_ALIGNED_ALLOC INTERCEPT_FUNCTION(aligned_alloc)
@@ -277,20 +277,20 @@ INTERCEPTOR(void *, aligned_alloc, SIZE_T alignment, SIZE_T size) {
 #endif
 
 INTERCEPTOR(int, posix_memalign, void **memptr, size_t alignment, size_t size) {
-  radsan::expectNotRealtime("posix_memalign");
+  radsan::ExpectNotRealtime("posix_memalign");
   return REAL(posix_memalign)(memptr, alignment, size);
 }
 
 #if SANITIZER_INTERCEPT_MEMALIGN
 INTERCEPTOR(void *, memalign, size_t alignment, size_t size) {
-  radsan::expectNotRealtime("memalign");
+  radsan::ExpectNotRealtime("memalign");
   return REAL(memalign)(alignment, size);
 }
 #endif
 
 #if SANITIZER_INTERCEPT_PVALLOC
 INTERCEPTOR(void *, pvalloc, size_t size) {
-  radsan::expectNotRealtime("pvalloc");
+  radsan::ExpectNotRealtime("pvalloc");
   return REAL(pvalloc)(size);
 }
 #endif
@@ -300,45 +300,45 @@ INTERCEPTOR(void *, pvalloc, size_t size) {
 */
 
 INTERCEPTOR(int, socket, int domain, int type, int protocol) {
-  radsan::expectNotRealtime("socket");
+  radsan::ExpectNotRealtime("socket");
   return REAL(socket)(domain, type, protocol);
 }
 
 INTERCEPTOR(ssize_t, send, int sockfd, const void *buf, size_t len, int flags) {
-  radsan::expectNotRealtime("send");
+  radsan::ExpectNotRealtime("send");
   return REAL(send)(sockfd, buf, len, flags);
 }
 
 INTERCEPTOR(ssize_t, sendmsg, int socket, const struct msghdr *message,
             int flags) {
-  radsan::expectNotRealtime("sendmsg");
+  radsan::ExpectNotRealtime("sendmsg");
   return REAL(sendmsg)(socket, message, flags);
 }
 
 INTERCEPTOR(ssize_t, sendto, int socket, const void *buffer, size_t length,
             int flags, const struct sockaddr *dest_addr, socklen_t dest_len) {
-  radsan::expectNotRealtime("sendto");
+  radsan::ExpectNotRealtime("sendto");
   return REAL(sendto)(socket, buffer, length, flags, dest_addr, dest_len);
 }
 
 INTERCEPTOR(ssize_t, recv, int socket, void *buffer, size_t length, int flags) {
-  radsan::expectNotRealtime("recv");
+  radsan::ExpectNotRealtime("recv");
   return REAL(recv)(socket, buffer, length, flags);
 }
 
 INTERCEPTOR(ssize_t, recvfrom, int socket, void *buffer, size_t length,
             int flags, struct sockaddr *address, socklen_t *address_len) {
-  radsan::expectNotRealtime("recvfrom");
+  radsan::ExpectNotRealtime("recvfrom");
   return REAL(recvfrom)(socket, buffer, length, flags, address, address_len);
 }
 
 INTERCEPTOR(ssize_t, recvmsg, int socket, struct msghdr *message, int flags) {
-  radsan::expectNotRealtime("recvmsg");
+  radsan::ExpectNotRealtime("recvmsg");
   return REAL(recvmsg)(socket, message, flags);
 }
 
 INTERCEPTOR(int, shutdown, int socket, int how) {
-  radsan::expectNotRealtime("shutdown");
+  radsan::ExpectNotRealtime("shutdown");
   return REAL(shutdown)(socket, how);
 }
 

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -39,7 +39,7 @@ using namespace __sanitizer;
 
 namespace radsan {
 void ExpectNotRealtime(const char *InterceptedFunctionName) {
-  getContextForThisThread().ExpectNotRealtime(InterceptedFunctionName);
+  GetContextForThisThread().ExpectNotRealtime(InterceptedFunctionName);
 }
 } // namespace radsan
 
@@ -347,7 +347,7 @@ INTERCEPTOR(int, shutdown, int socket, int how) {
 */
 
 namespace radsan {
-void initialiseInterceptors() {
+void InitializeInterceptors() {
   INTERCEPT_FUNCTION(calloc);
   INTERCEPT_FUNCTION(free);
   INTERCEPT_FUNCTION(malloc);

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_interceptors.cpp - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #include "radsan/radsan_interceptors.h"
 

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -53,7 +53,7 @@ INTERCEPTOR(int, open, const char *path, int oflag, ...) {
   radsan::expectNotRealtime("open");
   va_list args;
   va_start(args, oflag);
-  auto result = REAL(open)(path, oflag, args);
+  const int result = REAL(open)(path, oflag, args);
   va_end(args);
   return result;
 }
@@ -64,7 +64,7 @@ INTERCEPTOR(int, openat, int fd, const char *path, int oflag, ...) {
   radsan::expectNotRealtime("openat");
   va_list args;
   va_start(args, oflag);
-  auto result = REAL(openat)(fd, path, oflag, args);
+  const int result = REAL(openat)(fd, path, oflag, args);
   va_end(args);
   return result;
 }
@@ -73,7 +73,7 @@ INTERCEPTOR(int, creat, const char *path, mode_t mode) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
   radsan::expectNotRealtime("creat");
-  auto result = REAL(creat)(path, mode);
+  const int result = REAL(creat)(path, mode);
   return result;
 }
 
@@ -81,7 +81,7 @@ INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
   radsan::expectNotRealtime("fcntl");
   va_list args;
   va_start(args, cmd);
-  auto result = REAL(fcntl)(filedes, cmd, args);
+  const int result = REAL(fcntl)(filedes, cmd, args);
   va_end(args);
   return result;
 }

--- a/compiler-rt/lib/radsan/radsan_interceptors.h
+++ b/compiler-rt/lib/radsan/radsan_interceptors.h
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_interceptors.h - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/compiler-rt/lib/radsan/radsan_interceptors.h
+++ b/compiler-rt/lib/radsan/radsan_interceptors.h
@@ -9,5 +9,5 @@
 #pragma once
 
 namespace radsan {
-void initialiseInterceptors();
+void InitializeInterceptors();
 }

--- a/compiler-rt/lib/radsan/radsan_preinit.cpp
+++ b/compiler-rt/lib/radsan/radsan_preinit.cpp
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_preinit.cpp - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #include "sanitizer_common/sanitizer_internal_defs.h"
 #include <radsan/radsan.h>

--- a/compiler-rt/lib/radsan/radsan_stack.cpp
+++ b/compiler-rt/lib/radsan/radsan_stack.cpp
@@ -26,7 +26,7 @@ void BufferedStackTrace::UnwindImpl(uptr pc, uptr bp, void *context,
 } // namespace __sanitizer
 
 namespace {
-void setGlobalStackTraceFormat() {
+void SetGlobalStackTraceFormat() {
   SetCommonFlagsDefaults();
   CommonFlags cf;
   cf.CopyFrom(*common_flags());
@@ -37,14 +37,14 @@ void setGlobalStackTraceFormat() {
 } // namespace
 
 namespace radsan {
-void printStackTrace() {
+void PrintStackTrace() {
 
-  auto stack = BufferedStackTrace{};
+  BufferedStackTrace Stack{};
 
   GET_CURRENT_PC_BP;
-  stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal);
+  Stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal);
 
-  setGlobalStackTraceFormat();
-  stack.Print();
+  SetGlobalStackTraceFormat();
+  Stack.Print();
 }
 } // namespace radsan

--- a/compiler-rt/lib/radsan/radsan_stack.cpp
+++ b/compiler-rt/lib/radsan/radsan_stack.cpp
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_stack.cpp - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #include <sanitizer_common/sanitizer_flags.h>
 #include <sanitizer_common/sanitizer_stacktrace.h>

--- a/compiler-rt/lib/radsan/radsan_stack.h
+++ b/compiler-rt/lib/radsan/radsan_stack.h
@@ -1,10 +1,12 @@
-/**
-    This file is part of the RealtimeSanitizer (RADSan) project.
-    https://github.com/realtime-sanitizer/radsan
-
-    Copyright 2023 David Trevelyan & Alistair Barker
-    Subject to GNU General Public License (GPL) v3.0
-*/
+//===--- radsan_stack.h - Realtime Sanitizer --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/compiler-rt/lib/radsan/radsan_stack.h
+++ b/compiler-rt/lib/radsan/radsan_stack.h
@@ -9,5 +9,5 @@
 #pragma once
 
 namespace radsan {
-void printStackTrace();
+void PrintStackTrace();
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test.cpp
@@ -59,14 +59,14 @@ TEST(TestRadsan, SleepingAThreadDiesWhenRealtime) {
 }
 
 TEST(TestRadsan, IfstreamCreationDiesWhenRealtime) {
-  auto Func = []() { auto ifs = std::ifstream("./file.txt"); };
+  auto Func = []() { std::ifstream ifs{"./file.txt"}; };
   ExpectRealtimeDeath(Func);
   ExpectNonRealtimeSurvival(Func);
   std::remove("./file.txt");
 }
 
 TEST(TestRadsan, OfstreamCreationDiesWhenRealtime) {
-  auto Func = []() { auto ofs = std::ofstream("./file.txt"); };
+  auto Func = []() { std::ofstream ofs{"./file.txt"}; };
   ExpectRealtimeDeath(Func);
   ExpectNonRealtimeSurvival(Func);
   std::remove("./file.txt");
@@ -123,8 +123,8 @@ TEST(TestRadsan, SharedUnlockingASharedMutexDiesWhenRealtime) {
 
 TEST(TestRadsan, LaunchingAThreadDiesWhenRealtime) {
   auto Func = [&]() {
-    auto t = std::thread([]() {});
-    t.join();
+    std::thread Thread{[]() {}};
+    Thread.join();
   };
   ExpectRealtimeDeath(Func);
   ExpectNonRealtimeSurvival(Func);

--- a/compiler-rt/lib/radsan/tests/radsan_test.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test.cpp
@@ -34,168 +34,168 @@ using namespace testing;
 using namespace radsan_testing;
 using namespace std::chrono_literals;
 
-namespace {
-void invokeStdFunction(std::function<void()> &&function) { function(); }
-} // namespace
-
-TEST(TestRadsan, vectorPushBackAllocationDiesWhenRealtime) {
-  auto vec = std::vector<float>{};
-  auto func = [&vec]() { vec.push_back(0.4f); };
-  expectRealtimeDeath(func);
-  ASSERT_EQ(0u, vec.size());
-  expectNonrealtimeSurvival(func);
-  ASSERT_EQ(1u, vec.size());
+TEST(TestRadsan, VectorPushBackAllocationDiesWhenRealtime) {
+  std::vector<float> Vec{};
+  auto Func = [&Vec]() { Vec.push_back(0.4f); };
+  ExpectRealtimeDeath(Func);
+  ASSERT_EQ(0u, Vec.size());
+  ExpectNonRealtimeSurvival(Func);
+  ASSERT_EQ(1u, Vec.size());
 }
 
-TEST(TestRadsan, destructionOfObjectOnHeapDiesWhenRealtime) {
-  auto obj = std::make_unique<std::array<float, 256>>();
-  auto func = [&obj]() { obj.reset(); };
-  expectRealtimeDeath(func);
-  ASSERT_NE(nullptr, obj.get());
-  expectNonrealtimeSurvival(func);
-  ASSERT_EQ(nullptr, obj.get());
+TEST(TestRadsan, DestructionOfObjectOnHeapDiesWhenRealtime) {
+  auto AllocatedPtr = std::make_unique<std::array<float, 256>>();
+  auto Func = [&AllocatedPtr]() { AllocatedPtr.reset(); };
+  ExpectRealtimeDeath(Func);
+  ASSERT_NE(nullptr, AllocatedPtr.get());
+  ExpectNonRealtimeSurvival(Func);
+  ASSERT_EQ(nullptr, AllocatedPtr.get());
 }
 
-TEST(TestRadsan, sleepingAThreadDiesWhenRealtime) {
-  auto func = []() { std::this_thread::sleep_for(1us); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, SleepingAThreadDiesWhenRealtime) {
+  auto Func = []() { std::this_thread::sleep_for(1us); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, ifstreamCreationDiesWhenRealtime) {
-  auto func = []() { auto ifs = std::ifstream("./file.txt"); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, IfstreamCreationDiesWhenRealtime) {
+  auto Func = []() { auto ifs = std::ifstream("./file.txt"); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
   std::remove("./file.txt");
 }
 
-TEST(TestRadsan, ofstreamCreationDiesWhenRealtime) {
-  auto func = []() { auto ofs = std::ofstream("./file.txt"); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, OfstreamCreationDiesWhenRealtime) {
+  auto Func = []() { auto ofs = std::ofstream("./file.txt"); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
   std::remove("./file.txt");
 }
 
-TEST(TestRadsan, lockingAMutexDiesWhenRealtime) {
-  auto mutex = std::mutex{};
-  auto func = [&]() { mutex.lock(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, LockingAMutexDiesWhenRealtime) {
+  std::mutex Mutex{};
+  auto Func = [&]() { Mutex.lock(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, unlockingAMutexDiesWhenRealtime) {
-  auto mutex = std::mutex{};
-  mutex.lock();
-  auto func = [&]() { mutex.unlock(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, UnlockingAMutexDiesWhenRealtime) {
+  std::mutex Mutex{};
+  Mutex.lock();
+  auto Func = [&]() { Mutex.unlock(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #if RADSAN_TEST_SHARED_MUTEX
 
-TEST(TestRadsan, lockingASharedMutexDiesWhenRealtime) {
-  auto mutex = std::shared_mutex();
-  auto func = [&]() { mutex.lock(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, LockingASharedMutexDiesWhenRealtime) {
+  std::shared_mutex Mutex{};
+  auto Func = [&]() { Mutex.lock(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, unlockingASharedMutexDiesWhenRealtime) {
-  auto mutex = std::shared_mutex();
-  mutex.lock();
-  auto func = [&]() { mutex.unlock(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, UnlockingASharedMutexDiesWhenRealtime) {
+  std::shared_mutex Mutex{};
+  Mutex.lock();
+  auto Func = [&]() { Mutex.unlock(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, sharedLockingASharedMutexDiesWhenRealtime) {
-  auto mutex = std::shared_mutex();
-  auto func = [&]() { mutex.lock_shared(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, SharedLockingASharedMutexDiesWhenRealtime) {
+  std::shared_mutex Mutex{};
+  auto Func = [&]() { Mutex.lock_shared(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, sharedUnlockingASharedMutexDiesWhenRealtime) {
-  auto mutex = std::shared_mutex();
-  mutex.lock_shared();
-  auto func = [&]() { mutex.unlock_shared(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, SharedUnlockingASharedMutexDiesWhenRealtime) {
+  std::shared_mutex Mutex{};
+  Mutex.lock_shared();
+  auto Func = [&]() { Mutex.unlock_shared(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #endif // RADSAN_TEST_SHARED_MUTEX
 
-TEST(TestRadsan, launchingAThreadDiesWhenRealtime) {
-  auto func = [&]() {
+TEST(TestRadsan, LaunchingAThreadDiesWhenRealtime) {
+  auto Func = [&]() {
     auto t = std::thread([]() {});
     t.join();
   };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, copyingALambdaWithLargeCaptureDiesWhenRealtime) {
-  auto lots_of_data = std::array<float, 16>{};
-  auto lambda = [lots_of_data]() mutable {
+namespace {
+void InvokeStdFunction(std::function<void()> &&function) { function(); }
+} // namespace
+
+TEST(TestRadsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
+  std::array<float, 16> LotsOfData{};
+  auto lambda = [LotsOfData]() mutable {
     // Stop everything getting optimised out
-    lots_of_data[3] = 0.25f;
-    EXPECT_EQ(16, lots_of_data.size());
-    EXPECT_EQ(0.25f, lots_of_data[3]);
+    LotsOfData[3] = 0.25f;
+    EXPECT_EQ(16, LotsOfData.size());
+    EXPECT_EQ(0.25f, LotsOfData[3]);
   };
-  auto func = [&]() { invokeStdFunction(lambda); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  auto Func = [&]() { InvokeStdFunction(lambda); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, accessingALargeAtomicVariableDiesWhenRealtime) {
-  auto small_atomic = std::atomic<float>{0.0f};
-  ASSERT_TRUE(small_atomic.is_lock_free());
-  realtimeInvoke([&small_atomic]() { auto x = small_atomic.load(); });
+TEST(TestRadsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
+  std::atomic<float> SmallAtomic{0.0f};
+  ASSERT_TRUE(SmallAtomic.is_lock_free());
+  realtimeInvoke([&SmallAtomic]() { float x = SmallAtomic.load(); });
 
-  auto large_atomic = std::atomic<std::array<float, 2048>>{{}};
-  ASSERT_FALSE(large_atomic.is_lock_free());
-  auto func = [&]() { auto x = large_atomic.load(); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  std::atomic<std::array<float, 2048>> LargeAtomic{};
+  ASSERT_FALSE(LargeAtomic.is_lock_free());
+  auto Func = [&]() { auto x = LargeAtomic.load(); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, firstCoutDiesWhenRealtime) {
-  auto func = []() { std::cout << "Hello, world!" << std::endl; };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, FirstCoutDiesWhenRealtime) {
+  auto Func = []() { std::cout << "Hello, world!" << std::endl; };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, secondCoutDiesWhenRealtime) {
+TEST(TestRadsan, SecondCoutDiesWhenRealtime) {
   std::cout << "Hello, world";
-  auto func = []() { std::cout << "Hello, again!" << std::endl; };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  auto Func = []() { std::cout << "Hello, again!" << std::endl; };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, printfDiesWhenRealtime) {
-  auto func = []() { printf("Hello, world!\n"); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+TEST(TestRadsan, PrintfDiesWhenRealtime) {
+  auto Func = []() { printf("Hello, world!\n"); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, throwingAnExceptionDiesWhenRealtime) {
-  auto func = [&]() {
+TEST(TestRadsan, ThrowingAnExceptionDiesWhenRealtime) {
+  auto Func = [&]() {
     try {
       throw std::exception();
     } catch (std::exception &) {
     }
   };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsan, doesNotDieIfTurnedOff) {
-  auto mutex = std::mutex{};
-  auto realtime_unsafe_func = [&]() {
+TEST(TestRadsan, DoesNotDieIfTurnedOff) {
+  std::mutex Mutex{};
+  auto RealtimeUnsafeFunc = [&]() {
     radsan_off();
-    mutex.lock();
-    mutex.unlock();
+    Mutex.lock();
+    Mutex.unlock();
     radsan_on();
   };
-  realtimeInvoke(realtime_unsafe_func);
+  realtimeInvoke(RealtimeUnsafeFunc);
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test.cpp
@@ -150,7 +150,7 @@ TEST(TestRadsan, CopyingALambdaWithLargeCaptureDiesWhenRealtime) {
 TEST(TestRadsan, AccessingALargeAtomicVariableDiesWhenRealtime) {
   std::atomic<float> SmallAtomic{0.0f};
   ASSERT_TRUE(SmallAtomic.is_lock_free());
-  realtimeInvoke([&SmallAtomic]() { float x = SmallAtomic.load(); });
+  RealtimeInvoke([&SmallAtomic]() { float x = SmallAtomic.load(); });
 
   std::atomic<std::array<float, 2048>> LargeAtomic{};
   ASSERT_FALSE(LargeAtomic.is_lock_free());
@@ -197,5 +197,5 @@ TEST(TestRadsan, DoesNotDieIfTurnedOff) {
     Mutex.unlock();
     radsan_on();
   };
-  realtimeInvoke(RealtimeUnsafeFunc);
+  RealtimeInvoke(RealtimeUnsafeFunc);
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
@@ -12,56 +12,56 @@
 
 TEST(TestRadsanContext, canCreateContext) { auto context = radsan::Context{}; }
 
-TEST(TestRadsanContext, expectNotRealtimeDoesNotDieBeforeRealtimePush) {
+TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieBeforeRealtimePush) {
   auto context = radsan::Context{};
-  context.expectNotRealtime("do_some_stuff");
+  context.ExpectNotRealtime("do_some_stuff");
 }
 
-TEST(TestRadsanContext, expectNotRealtimeDoesNotDieAfterPushAndPop) {
+TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieAfterPushAndPop) {
   auto context = radsan::Context{};
-  context.realtimePush();
-  context.realtimePop();
-  context.expectNotRealtime("do_some_stuff");
+  context.RealtimePush();
+  context.RealtimePop();
+  context.ExpectNotRealtime("do_some_stuff");
 }
 
-TEST(TestRadsanContext, expectNotRealtimeDiesAfterRealtimePush) {
+TEST(TestRadsanContext, ExpectNotRealtimeDiesAfterRealtimePush) {
   auto context = radsan::Context{};
 
-  context.realtimePush();
-  EXPECT_DEATH(context.expectNotRealtime("do_some_stuff"), "");
-}
-
-TEST(TestRadsanContext,
-     expectNotRealtimeDiesAfterRealtimeAfterMorePushesThanPops) {
-  auto context = radsan::Context{};
-
-  context.realtimePush();
-  context.realtimePush();
-  context.realtimePush();
-  context.realtimePop();
-  context.realtimePop();
-  EXPECT_DEATH(context.expectNotRealtime("do_some_stuff"), "");
-}
-
-TEST(TestRadsanContext, expectNotRealtimeDoesNotDieAfterBypassPush) {
-  auto context = radsan::Context{};
-
-  context.realtimePush();
-  context.bypassPush();
-  context.expectNotRealtime("do_some_stuff");
+  context.RealtimePush();
+  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
 }
 
 TEST(TestRadsanContext,
-     expectNotRealtimeDoesNotDieIfBypassDepthIsGreaterThanZero) {
+     ExpectNotRealtimeDiesAfterRealtimeAfterMorePushesThanPops) {
   auto context = radsan::Context{};
 
-  context.realtimePush();
-  context.bypassPush();
-  context.bypassPush();
-  context.bypassPush();
-  context.bypassPop();
-  context.bypassPop();
-  context.expectNotRealtime("do_some_stuff");
-  context.bypassPop();
-  EXPECT_DEATH(context.expectNotRealtime("do_some_stuff"), "");
+  context.RealtimePush();
+  context.RealtimePush();
+  context.RealtimePush();
+  context.RealtimePop();
+  context.RealtimePop();
+  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+}
+
+TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieAfterBypassPush) {
+  auto context = radsan::Context{};
+
+  context.RealtimePush();
+  context.BypassPush();
+  context.ExpectNotRealtime("do_some_stuff");
+}
+
+TEST(TestRadsanContext,
+     ExpectNotRealtimeDoesNotDieIfBypassDepthIsGreaterThanZero) {
+  auto context = radsan::Context{};
+
+  context.RealtimePush();
+  context.BypassPush();
+  context.BypassPush();
+  context.BypassPush();
+  context.BypassPop();
+  context.BypassPop();
+  context.ExpectNotRealtime("do_some_stuff");
+  context.BypassPop();
+  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_context.cpp
@@ -10,58 +10,58 @@
 
 #include "radsan_context.h"
 
-TEST(TestRadsanContext, canCreateContext) { auto context = radsan::Context{}; }
+TEST(TestRadsanContext, CanCreateContext) { radsan::Context Context{}; }
 
 TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieBeforeRealtimePush) {
-  auto context = radsan::Context{};
-  context.ExpectNotRealtime("do_some_stuff");
+  radsan::Context Context{};
+  Context.ExpectNotRealtime("do_some_stuff");
 }
 
 TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieAfterPushAndPop) {
-  auto context = radsan::Context{};
-  context.RealtimePush();
-  context.RealtimePop();
-  context.ExpectNotRealtime("do_some_stuff");
+  radsan::Context Context{};
+  Context.RealtimePush();
+  Context.RealtimePop();
+  Context.ExpectNotRealtime("do_some_stuff");
 }
 
 TEST(TestRadsanContext, ExpectNotRealtimeDiesAfterRealtimePush) {
-  auto context = radsan::Context{};
+  radsan::Context Context{};
 
-  context.RealtimePush();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  Context.RealtimePush();
+  EXPECT_DEATH(Context.ExpectNotRealtime("do_some_stuff"), "");
 }
 
 TEST(TestRadsanContext,
      ExpectNotRealtimeDiesAfterRealtimeAfterMorePushesThanPops) {
-  auto context = radsan::Context{};
+  radsan::Context Context{};
 
-  context.RealtimePush();
-  context.RealtimePush();
-  context.RealtimePush();
-  context.RealtimePop();
-  context.RealtimePop();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  Context.RealtimePush();
+  Context.RealtimePush();
+  Context.RealtimePush();
+  Context.RealtimePop();
+  Context.RealtimePop();
+  EXPECT_DEATH(Context.ExpectNotRealtime("do_some_stuff"), "");
 }
 
 TEST(TestRadsanContext, ExpectNotRealtimeDoesNotDieAfterBypassPush) {
-  auto context = radsan::Context{};
+  radsan::Context Context{};
 
-  context.RealtimePush();
-  context.BypassPush();
-  context.ExpectNotRealtime("do_some_stuff");
+  Context.RealtimePush();
+  Context.BypassPush();
+  Context.ExpectNotRealtime("do_some_stuff");
 }
 
 TEST(TestRadsanContext,
      ExpectNotRealtimeDoesNotDieIfBypassDepthIsGreaterThanZero) {
-  auto context = radsan::Context{};
+  radsan::Context Context{};
 
-  context.RealtimePush();
-  context.BypassPush();
-  context.BypassPush();
-  context.BypassPush();
-  context.BypassPop();
-  context.BypassPop();
-  context.ExpectNotRealtime("do_some_stuff");
-  context.BypassPop();
-  EXPECT_DEATH(context.ExpectNotRealtime("do_some_stuff"), "");
+  Context.RealtimePush();
+  Context.BypassPush();
+  Context.BypassPush();
+  Context.BypassPush();
+  Context.BypassPop();
+  Context.BypassPop();
+  Context.ExpectNotRealtime("do_some_stuff");
+  Context.BypassPop();
+  EXPECT_DEATH(Context.ExpectNotRealtime("do_some_stuff"), "");
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -107,7 +107,7 @@ TEST(TestRadsanInterceptors, freeDiesWhenRealtime) {
 }
 
 TEST(TestRadsanInterceptors, freeSurvivesWhenRealtimeIfArgumentIsNull) {
-  realtimeInvoke([]() { free(NULL); });
+  RealtimeInvoke([]() { free(NULL); });
   ExpectNonRealtimeSurvival([]() { free(NULL); });
 }
 

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -36,7 +36,7 @@ using namespace radsan_testing;
 using namespace std::chrono_literals;
 
 namespace {
-void *fake_thread_entry_point(void *) { return nullptr; }
+void *FakeThreadEntryPoint(void *) { return nullptr; }
 
 /*
   The creat function doesn't seem to work on an ubuntu Docker image when the
@@ -45,7 +45,7 @@ void *fake_thread_entry_point(void *) { return nullptr; }
   shared volume (/tmp). This is volatile and will be cleaned up as soon as the
   container is stopped.
 */
-constexpr const char *temporary_file_path() {
+constexpr const char *TemporaryFilePath() {
 #if SANITIZER_LINUX
   return "/tmp/radsan_temporary_test_file.txt";
 #elif SANITIZER_APPLE
@@ -58,46 +58,46 @@ constexpr const char *temporary_file_path() {
     Allocation and deallocation
 */
 
-TEST(TestRadsanInterceptors, mallocDiesWhenRealtime) {
-  auto func = []() { EXPECT_NE(nullptr, malloc(1)); };
-  ExpectRealtimeDeath(func, "malloc");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, MallocDiesWhenRealtime) {
+  auto Func = []() { EXPECT_NE(nullptr, malloc(1)); };
+  ExpectRealtimeDeath(Func, "malloc");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, reallocDiesWhenRealtime) {
-  auto *ptr_1 = malloc(1);
-  auto func = [ptr_1]() { EXPECT_NE(nullptr, realloc(ptr_1, 8)); };
-  ExpectRealtimeDeath(func, "realloc");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, ReallocDiesWhenRealtime) {
+  void *ptr_1 = malloc(1);
+  auto Func = [ptr_1]() { EXPECT_NE(nullptr, realloc(ptr_1, 8)); };
+  ExpectRealtimeDeath(Func, "realloc");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #if SANITIZER_APPLE
-TEST(TestRadsanInterceptors, reallocfDiesWhenRealtime) {
-  auto *ptr_1 = malloc(1);
-  auto func = [ptr_1]() { EXPECT_NE(nullptr, reallocf(ptr_1, 8)); };
-  ExpectRealtimeDeath(func, "reallocf");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, ReallocfDiesWhenRealtime) {
+  void *ptr_1 = malloc(1);
+  auto Func = [ptr_1]() { EXPECT_NE(nullptr, reallocf(ptr_1, 8)); };
+  ExpectRealtimeDeath(Func, "reallocf");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
-TEST(TestRadsanInterceptors, vallocDiesWhenRealtime) {
-  auto func = []() { EXPECT_NE(nullptr, valloc(4)); };
-  ExpectRealtimeDeath(func, "valloc");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, VallocDiesWhenRealtime) {
+  auto Func = []() { EXPECT_NE(nullptr, valloc(4)); };
+  ExpectRealtimeDeath(Func, "valloc");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #if SANITIZER_INTERCEPT_ALIGNED_ALLOC
-TEST(TestRadsanInterceptors, alignedAllocDiesWhenRealtime) {
-  auto func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
-  ExpectRealtimeDeath(func, "aligned_alloc");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, AlignedAllocDiesWhenRealtime) {
+  auto Func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
+  ExpectRealtimeDeath(Func, "aligned_alloc");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
 // free_sized and free_aligned_sized (both C23) are not yet supported
-TEST(TestRadsanInterceptors, freeDiesWhenRealtime) {
-  auto *ptr_1 = malloc(1);
-  auto *ptr_2 = malloc(1);
+TEST(TestRadsanInterceptors, FreeDiesWhenRealtime) {
+  void *ptr_1 = malloc(1);
+  void *ptr_2 = malloc(1);
   ExpectRealtimeDeath([ptr_1]() { free(ptr_1); }, "free");
   ExpectNonRealtimeSurvival([ptr_2]() { free(ptr_2); });
 
@@ -106,33 +106,33 @@ TEST(TestRadsanInterceptors, freeDiesWhenRealtime) {
   ASSERT_NE(nullptr, ptr_2);
 }
 
-TEST(TestRadsanInterceptors, freeSurvivesWhenRealtimeIfArgumentIsNull) {
+TEST(TestRadsanInterceptors, FreeSurvivesWhenRealtimeIfArgumentIsNull) {
   RealtimeInvoke([]() { free(NULL); });
   ExpectNonRealtimeSurvival([]() { free(NULL); });
 }
 
-TEST(TestRadsanInterceptors, posixMemalignDiesWhenRealtime) {
-  auto func = []() {
-    void *mem;
-    posix_memalign(&mem, 4, 4);
+TEST(TestRadsanInterceptors, PosixMemalignDiesWhenRealtime) {
+  auto Func = []() {
+    void *Mem;
+    posix_memalign(&Mem, 4, 4);
   };
-  ExpectRealtimeDeath(func, "posix_memalign");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "posix_memalign");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #if SANITIZER_INTERCEPT_MEMALIGN
-TEST(TestRadsanInterceptors, memalignDiesWhenRealtime) {
-  auto func = []() { EXPECT_NE(memalign(2, 2048), nullptr); };
-  ExpectRealtimeDeath(func, "memalign");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, MemalignDiesWhenRealtime) {
+  auto Func = []() { EXPECT_NE(memalign(2, 2048), nullptr); };
+  ExpectRealtimeDeath(Func, "memalign");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
 #if SANITIZER_INTERCEPT_PVALLOC
-TEST(TestRadsanInterceptors, pvallocDiesWhenRealtime) {
-  auto func = []() { EXPECT_NE(pvalloc(2048), nullptr); };
-  ExpectRealtimeDeath(func, "pvalloc");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, PvallocDiesWhenRealtime) {
+  auto Func = []() { EXPECT_NE(pvalloc(2048), nullptr); };
+  ExpectRealtimeDeath(Func, "pvalloc");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
@@ -140,166 +140,166 @@ TEST(TestRadsanInterceptors, pvallocDiesWhenRealtime) {
     Sleeping
 */
 
-TEST(TestRadsanInterceptors, sleepDiesWhenRealtime) {
-  auto func = []() { sleep(0u); };
-  ExpectRealtimeDeath(func, "sleep");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, SleepDiesWhenRealtime) {
+  auto Func = []() { sleep(0u); };
+  ExpectRealtimeDeath(Func, "sleep");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, usleepDiesWhenRealtime) {
-  auto func = []() { usleep(1u); };
-  ExpectRealtimeDeath(func, "usleep");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, UsleepDiesWhenRealtime) {
+  auto Func = []() { usleep(1u); };
+  ExpectRealtimeDeath(Func, "usleep");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, nanosleepDiesWhenRealtime) {
-  auto func = []() {
-    auto t = timespec{};
-    nanosleep(&t, &t);
+TEST(TestRadsanInterceptors, NanosleepDiesWhenRealtime) {
+  auto Func = []() {
+    timespec T{};
+    nanosleep(&T, &T);
   };
-  ExpectRealtimeDeath(func, "nanosleep");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "nanosleep");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 /*
     Filesystem
 */
 
-TEST(TestRadsanInterceptors, openDiesWhenRealtime) {
-  auto func = []() { open(temporary_file_path(), O_RDONLY); };
-  ExpectRealtimeDeath(func, "open");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, OpenDiesWhenRealtime) {
+  auto Func = []() { open(TemporaryFilePath(), O_RDONLY); };
+  ExpectRealtimeDeath(Func, "open");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, openatDiesWhenRealtime) {
-  auto func = []() { openat(0, temporary_file_path(), O_RDONLY); };
-  ExpectRealtimeDeath(func, "openat");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, OpenatDiesWhenRealtime) {
+  auto Func = []() { openat(0, TemporaryFilePath(), O_RDONLY); };
+  ExpectRealtimeDeath(Func, "openat");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, creatDiesWhenRealtime) {
-  auto func = []() { creat(temporary_file_path(), S_IWOTH | S_IROTH); };
-  ExpectRealtimeDeath(func, "creat");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, CreatDiesWhenRealtime) {
+  auto Func = []() { creat(TemporaryFilePath(), S_IWOTH | S_IROTH); };
+  ExpectRealtimeDeath(Func, "creat");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, fcntlDiesWhenRealtime) {
-  auto func = []() { fcntl(0, F_GETFL); };
-  ExpectRealtimeDeath(func, "fcntl");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, FcntlDiesWhenRealtime) {
+  auto Func = []() { fcntl(0, F_GETFL); };
+  ExpectRealtimeDeath(Func, "fcntl");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, closeDiesWhenRealtime) {
-  auto func = []() { close(0); };
-  ExpectRealtimeDeath(func, "close");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, CloseDiesWhenRealtime) {
+  auto Func = []() { close(0); };
+  ExpectRealtimeDeath(Func, "close");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, fopenDiesWhenRealtime) {
-  auto func = []() {
-    auto fd = fopen(temporary_file_path(), "w");
-    EXPECT_THAT(fd, Ne(nullptr));
+TEST(TestRadsanInterceptors, FopenDiesWhenRealtime) {
+  auto Func = []() {
+    FILE* Fd = fopen(TemporaryFilePath(), "w");
+    EXPECT_THAT(Fd, Ne(nullptr));
   };
-  ExpectRealtimeDeath(func, "fopen");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+  ExpectRealtimeDeath(Func, "fopen");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, freadDiesWhenRealtime) {
-  auto fd = fopen(temporary_file_path(), "w");
-  auto func = [fd]() {
+TEST(TestRadsanInterceptors, FreadDiesWhenRealtime) {
+  FILE* Fd = fopen(TemporaryFilePath(), "w");
+  auto Func = [Fd]() {
     char c{};
-    fread(&c, 1, 1, fd);
+    fread(&c, 1, 1, Fd);
   };
-  ExpectRealtimeDeath(func, "fread");
-  ExpectNonRealtimeSurvival(func);
-  if (fd != nullptr)
-    fclose(fd);
-  std::remove(temporary_file_path());
+  ExpectRealtimeDeath(Func, "fread");
+  ExpectNonRealtimeSurvival(Func);
+  if (Fd != nullptr)
+    fclose(Fd);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, fwriteDiesWhenRealtime) {
-  auto fd = fopen(temporary_file_path(), "w");
-  ASSERT_NE(nullptr, fd);
-  auto message = "Hello, world!";
-  auto func = [&]() { fwrite(&message, 1, 4, fd); };
-  ExpectRealtimeDeath(func, "fwrite");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, FwriteDiesWhenRealtime) {
+  FILE* Fd = fopen(TemporaryFilePath(), "w");
+  ASSERT_NE(nullptr, Fd);
+  const char* Message = "Hello, world!";
+  auto Func = [&]() { fwrite(&Message, 1, 4, Fd); };
+  ExpectRealtimeDeath(Func, "fwrite");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, fcloseDiesWhenRealtime) {
-  auto fd = fopen(temporary_file_path(), "w");
-  EXPECT_THAT(fd, Ne(nullptr));
-  auto func = [fd]() { fclose(fd); };
-  ExpectRealtimeDeath(func, "fclose");
-  ExpectNonRealtimeSurvival(func);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, FcloseDiesWhenRealtime) {
+  FILE* Fd = fopen(TemporaryFilePath(), "w");
+  EXPECT_THAT(Fd, Ne(nullptr));
+  auto Func = [Fd]() { fclose(Fd); };
+  ExpectRealtimeDeath(Func, "fclose");
+  ExpectNonRealtimeSurvival(Func);
+  std::remove(TemporaryFilePath());
 }
 
-TEST(TestRadsanInterceptors, putsDiesWhenRealtime) {
-  auto func = []() { puts("Hello, world!\n"); };
-  ExpectRealtimeDeath(func);
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, PutsDiesWhenRealtime) {
+  auto Func = []() { puts("Hello, world!\n"); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, fputsDiesWhenRealtime) {
-  auto fd = fopen(temporary_file_path(), "w");
-  ASSERT_THAT(fd, Ne(nullptr)) << errno;
-  auto func = [fd]() { fputs("Hello, world!\n", fd); };
-  ExpectRealtimeDeath(func);
-  ExpectNonRealtimeSurvival(func);
-  if (fd != nullptr)
-    fclose(fd);
-  std::remove(temporary_file_path());
+TEST(TestRadsanInterceptors, FputsDiesWhenRealtime) {
+  FILE* Fd = fopen(TemporaryFilePath(), "w");
+  ASSERT_THAT(Fd, Ne(nullptr)) << errno;
+  auto Func = [Fd]() { fputs("Hello, world!\n", Fd); };
+  ExpectRealtimeDeath(Func);
+  ExpectNonRealtimeSurvival(Func);
+  if (Fd != nullptr)
+    fclose(Fd);
+  std::remove(TemporaryFilePath());
 }
 
 /*
     Concurrency
 */
 
-TEST(TestRadsanInterceptors, pthreadCreateDiesWhenRealtime) {
-  auto func = []() {
-    auto thread = pthread_t{};
-    auto const attr = pthread_attr_t{};
-    struct thread_info *tinfo;
-    pthread_create(&thread, &attr, &fake_thread_entry_point, tinfo);
+TEST(TestRadsanInterceptors, PthreadCreateDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_t Thread{};
+    const pthread_attr_t Attr{};
+    struct thread_info *ThreadInfo;
+    pthread_create(&Thread, &Attr, &FakeThreadEntryPoint, ThreadInfo);
   };
-  ExpectRealtimeDeath(func, "pthread_create");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_create");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadMutexLockDiesWhenRealtime) {
-  auto func = []() {
-    auto mutex = pthread_mutex_t{};
-    pthread_mutex_lock(&mutex);
+TEST(TestRadsanInterceptors, PthreadMutexLockDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_mutex_t Mutex{};
+    pthread_mutex_lock(&Mutex);
   };
 
-  ExpectRealtimeDeath(func, "pthread_mutex_lock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_mutex_lock");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadMutexUnlockDiesWhenRealtime) {
-  auto func = []() {
-    auto mutex = pthread_mutex_t{};
-    pthread_mutex_unlock(&mutex);
+TEST(TestRadsanInterceptors, PthreadMutexUnlockDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_mutex_t Mutex{};
+    pthread_mutex_unlock(&Mutex);
   };
 
-  ExpectRealtimeDeath(func, "pthread_mutex_unlock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_mutex_unlock");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadMutexJoinDiesWhenRealtime) {
-  auto func = []() {
-    auto thread = pthread_t{};
-    pthread_join(thread, nullptr);
+TEST(TestRadsanInterceptors, PthreadMutexJoinDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_t Thread{};
+    pthread_join(Thread, nullptr);
   };
 
-  ExpectRealtimeDeath(func, "pthread_join");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_join");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 #if SANITIZER_APPLE
@@ -307,146 +307,146 @@ TEST(TestRadsanInterceptors, pthreadMutexJoinDiesWhenRealtime) {
 #pragma clang diagnostic push
 // OSSpinLockLock is deprecated, but still in use in libc++
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-TEST(TestRadsanInterceptors, osSpinLockLockDiesWhenRealtime) {
-  auto func = []() {
-    auto spin_lock = OSSpinLock{};
-    OSSpinLockLock(&spin_lock);
+TEST(TestRadsanInterceptors, OsSpinLockLockDiesWhenRealtime) {
+  auto Func = []() {
+    OSSpinLock SpinLock{};
+    OSSpinLockLock(&SpinLock);
   };
-  ExpectRealtimeDeath(func, "OSSpinLockLock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "OSSpinLockLock");
+  ExpectNonRealtimeSurvival(Func);
 }
 #pragma clang diagnostic pop
 
-TEST(TestRadsanInterceptors, osUnfairLockLockDiesWhenRealtime) {
-  auto func = []() {
-    auto unfair_lock = os_unfair_lock_s{};
-    os_unfair_lock_lock(&unfair_lock);
+TEST(TestRadsanInterceptors, OsUnfairLockLockDiesWhenRealtime) {
+  auto Func = []() {
+    os_unfair_lock_s UnfairLock{};
+    os_unfair_lock_lock(&UnfairLock);
   };
-  ExpectRealtimeDeath(func, "os_unfair_lock_lock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "os_unfair_lock_lock");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
 #if SANITIZER_LINUX
-TEST(TestRadsanInterceptors, spinLockLockDiesWhenRealtime) {
-  auto spinlock = pthread_spinlock_t{};
-  pthread_spin_init(&spinlock, PTHREAD_PROCESS_SHARED);
-  auto func = [&]() { pthread_spin_lock(&spinlock); };
-  ExpectRealtimeDeath(func, "pthread_spin_lock");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, SpinLockLockDiesWhenRealtime) {
+  pthread_spinlock_t SpinLock;
+  pthread_spin_init(&SpinLock, PTHREAD_PROCESS_SHARED);
+  auto Func = [&]() { pthread_spin_lock(&SpinLock); };
+  ExpectRealtimeDeath(Func, "pthread_spin_lock");
+  ExpectNonRealtimeSurvival(Func);
 }
 #endif
 
-TEST(TestRadsanInterceptors, pthreadCondSignalDiesWhenRealtime) {
-  auto func = []() {
-    auto cond = pthread_cond_t{};
-    pthread_cond_signal(&cond);
+TEST(TestRadsanInterceptors, PthreadCondSignalDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_cond_t Cond{};
+    pthread_cond_signal(&Cond);
   };
-  ExpectRealtimeDeath(func, "pthread_cond_signal");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_cond_signal");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadCondBroadcastDiesWhenRealtime) {
-  auto func = []() {
-    auto cond = pthread_cond_t{};
-    pthread_cond_broadcast(&cond);
+TEST(TestRadsanInterceptors, PthreadCondBroadcastDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_cond_t Cond;
+    pthread_cond_broadcast(&Cond);
   };
-  ExpectRealtimeDeath(func, "pthread_cond_broadcast");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_cond_broadcast");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadCondWaitDiesWhenRealtime) {
-  auto cond = pthread_cond_t{};
-  auto mutex = pthread_mutex_t{};
-  ASSERT_EQ(0, pthread_cond_init(&cond, nullptr));
-  ASSERT_EQ(0, pthread_mutex_init(&mutex, nullptr));
-  auto func = [&]() { pthread_cond_wait(&cond, &mutex); };
-  ExpectRealtimeDeath(func, "pthread_cond_wait");
+TEST(TestRadsanInterceptors, PthreadCondWaitDiesWhenRealtime) {
+  pthread_cond_t Cond;
+  pthread_mutex_t Mutex;
+  ASSERT_EQ(0, pthread_cond_init(&Cond, nullptr));
+  ASSERT_EQ(0, pthread_mutex_init(&Mutex, nullptr));
+  auto Func = [&]() { pthread_cond_wait(&Cond, &Mutex); };
+  ExpectRealtimeDeath(Func, "pthread_cond_wait");
   // It's very difficult to test the success case here without doing some
   // sleeping, which is at the mercy of the scheduler. What's really important
   // here is the interception - so we're only testing that for now.
 }
 
-TEST(TestRadsanInterceptors, pthreadRwlockRdlockDiesWhenRealtime) {
-  auto func = []() {
-    auto rwlock = pthread_rwlock_t{};
-    pthread_rwlock_rdlock(&rwlock);
+TEST(TestRadsanInterceptors, PthreadRwlockRdlockDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_rwlock_t RwLock;
+    pthread_rwlock_rdlock(&RwLock);
   };
-  ExpectRealtimeDeath(func, "pthread_rwlock_rdlock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_rwlock_rdlock");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadRwlockUnlockDiesWhenRealtime) {
-  auto func = []() {
-    auto rwlock = pthread_rwlock_t{};
-    pthread_rwlock_unlock(&rwlock);
+TEST(TestRadsanInterceptors, PthreadRwlockUnlockDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_rwlock_t RwLock;
+    pthread_rwlock_unlock(&RwLock);
   };
-  ExpectRealtimeDeath(func, "pthread_rwlock_unlock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_rwlock_unlock");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, pthreadRwlockWrlockDiesWhenRealtime) {
-  auto func = []() {
-    auto rwlock = pthread_rwlock_t{};
-    pthread_rwlock_wrlock(&rwlock);
+TEST(TestRadsanInterceptors, PthreadRwlockWrlockDiesWhenRealtime) {
+  auto Func = []() {
+    pthread_rwlock_t RwLock;
+    pthread_rwlock_wrlock(&RwLock);
   };
-  ExpectRealtimeDeath(func, "pthread_rwlock_wrlock");
-  ExpectNonRealtimeSurvival(func);
+  ExpectRealtimeDeath(Func, "pthread_rwlock_wrlock");
+  ExpectNonRealtimeSurvival(Func);
 }
 
 /*
     Sockets
 */
-TEST(TestRadsanInterceptors, openingASocketDiesWhenRealtime) {
-  auto func = []() { socket(PF_INET, SOCK_STREAM, 0); };
-  ExpectRealtimeDeath(func, "socket");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, OpeningASocketDiesWhenRealtime) {
+  auto Func = []() { socket(PF_INET, SOCK_STREAM, 0); };
+  ExpectRealtimeDeath(Func, "socket");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, sendToASocketDiesWhenRealtime) {
-  auto func = []() { send(0, nullptr, 0, 0); };
-  ExpectRealtimeDeath(func, "send");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, SendToASocketDiesWhenRealtime) {
+  auto Func = []() { send(0, nullptr, 0, 0); };
+  ExpectRealtimeDeath(Func, "send");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, sendmsgToASocketDiesWhenRealtime) {
-  auto const msg = msghdr{};
-  auto func = [&]() { sendmsg(0, &msg, 0); };
-  ExpectRealtimeDeath(func, "sendmsg");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, SendmsgToASocketDiesWhenRealtime) {
+  msghdr Msg{};
+  auto Func = [&]() { sendmsg(0, &Msg, 0); };
+  ExpectRealtimeDeath(Func, "sendmsg");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, sendtoToASocketDiesWhenRealtime) {
-  auto const addr = sockaddr{};
-  auto const len = socklen_t{};
-  auto func = [&]() { sendto(0, nullptr, 0, 0, &addr, len); };
-  ExpectRealtimeDeath(func, "sendto");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, SendtoToASocketDiesWhenRealtime) {
+  sockaddr Addr{};
+  socklen_t Len{};
+  auto Func = [&]() { sendto(0, nullptr, 0, 0, &Addr, Len); };
+  ExpectRealtimeDeath(Func, "sendto");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, recvFromASocketDiesWhenRealtime) {
-  auto func = []() { recv(0, nullptr, 0, 0); };
-  ExpectRealtimeDeath(func, "recv");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, RecvFromASocketDiesWhenRealtime) {
+  auto Func = []() { recv(0, nullptr, 0, 0); };
+  ExpectRealtimeDeath(Func, "recv");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, recvfromOnASocketDiesWhenRealtime) {
-  auto addr = sockaddr{};
-  auto len = socklen_t{};
-  auto func = [&]() { recvfrom(0, nullptr, 0, 0, &addr, &len); };
-  ExpectRealtimeDeath(func, "recvfrom");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, RecvfromOnASocketDiesWhenRealtime) {
+  sockaddr Addr{};
+  socklen_t Len{};
+  auto Func = [&]() { recvfrom(0, nullptr, 0, 0, &Addr, &Len); };
+  ExpectRealtimeDeath(Func, "recvfrom");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, recvmsgOnASocketDiesWhenRealtime) {
-  auto msg = msghdr{};
-  auto func = [&]() { recvmsg(0, &msg, 0); };
-  ExpectRealtimeDeath(func, "recvmsg");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, RecvmsgOnASocketDiesWhenRealtime) {
+  msghdr Msg{};
+  auto Func = [&]() { recvmsg(0, &Msg, 0); };
+  ExpectRealtimeDeath(Func, "recvmsg");
+  ExpectNonRealtimeSurvival(Func);
 }
 
-TEST(TestRadsanInterceptors, shutdownOnASocketDiesWhenRealtime) {
-  auto func = [&]() { shutdown(0, 0); };
-  ExpectRealtimeDeath(func, "shutdown");
-  ExpectNonRealtimeSurvival(func);
+TEST(TestRadsanInterceptors, ShutdownOnASocketDiesWhenRealtime) {
+  auto Func = [&]() { shutdown(0, 0); };
+  ExpectRealtimeDeath(Func, "shutdown");
+  ExpectNonRealtimeSurvival(Func);
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -60,37 +60,37 @@ constexpr const char *temporary_file_path() {
 
 TEST(TestRadsanInterceptors, mallocDiesWhenRealtime) {
   auto func = []() { EXPECT_NE(nullptr, malloc(1)); };
-  expectRealtimeDeath(func, "malloc");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "malloc");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, reallocDiesWhenRealtime) {
   auto *ptr_1 = malloc(1);
   auto func = [ptr_1]() { EXPECT_NE(nullptr, realloc(ptr_1, 8)); };
-  expectRealtimeDeath(func, "realloc");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "realloc");
+  ExpectNonRealtimeSurvival(func);
 }
 
 #if SANITIZER_APPLE
 TEST(TestRadsanInterceptors, reallocfDiesWhenRealtime) {
   auto *ptr_1 = malloc(1);
   auto func = [ptr_1]() { EXPECT_NE(nullptr, reallocf(ptr_1, 8)); };
-  expectRealtimeDeath(func, "reallocf");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "reallocf");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
 TEST(TestRadsanInterceptors, vallocDiesWhenRealtime) {
   auto func = []() { EXPECT_NE(nullptr, valloc(4)); };
-  expectRealtimeDeath(func, "valloc");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "valloc");
+  ExpectNonRealtimeSurvival(func);
 }
 
 #if SANITIZER_INTERCEPT_ALIGNED_ALLOC
 TEST(TestRadsanInterceptors, alignedAllocDiesWhenRealtime) {
   auto func = []() { EXPECT_NE(nullptr, aligned_alloc(16, 32)); };
-  expectRealtimeDeath(func, "aligned_alloc");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "aligned_alloc");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
@@ -98,8 +98,8 @@ TEST(TestRadsanInterceptors, alignedAllocDiesWhenRealtime) {
 TEST(TestRadsanInterceptors, freeDiesWhenRealtime) {
   auto *ptr_1 = malloc(1);
   auto *ptr_2 = malloc(1);
-  expectRealtimeDeath([ptr_1]() { free(ptr_1); }, "free");
-  expectNonrealtimeSurvival([ptr_2]() { free(ptr_2); });
+  ExpectRealtimeDeath([ptr_1]() { free(ptr_1); }, "free");
+  ExpectNonRealtimeSurvival([ptr_2]() { free(ptr_2); });
 
   // Prevent malloc/free pair being optimised out
   ASSERT_NE(nullptr, ptr_1);
@@ -108,7 +108,7 @@ TEST(TestRadsanInterceptors, freeDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, freeSurvivesWhenRealtimeIfArgumentIsNull) {
   realtimeInvoke([]() { free(NULL); });
-  expectNonrealtimeSurvival([]() { free(NULL); });
+  ExpectNonRealtimeSurvival([]() { free(NULL); });
 }
 
 TEST(TestRadsanInterceptors, posixMemalignDiesWhenRealtime) {
@@ -116,23 +116,23 @@ TEST(TestRadsanInterceptors, posixMemalignDiesWhenRealtime) {
     void *mem;
     posix_memalign(&mem, 4, 4);
   };
-  expectRealtimeDeath(func, "posix_memalign");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "posix_memalign");
+  ExpectNonRealtimeSurvival(func);
 }
 
 #if SANITIZER_INTERCEPT_MEMALIGN
 TEST(TestRadsanInterceptors, memalignDiesWhenRealtime) {
   auto func = []() { EXPECT_NE(memalign(2, 2048), nullptr); };
-  expectRealtimeDeath(func, "memalign");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "memalign");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
 #if SANITIZER_INTERCEPT_PVALLOC
 TEST(TestRadsanInterceptors, pvallocDiesWhenRealtime) {
   auto func = []() { EXPECT_NE(pvalloc(2048), nullptr); };
-  expectRealtimeDeath(func, "pvalloc");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pvalloc");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
@@ -142,14 +142,14 @@ TEST(TestRadsanInterceptors, pvallocDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, sleepDiesWhenRealtime) {
   auto func = []() { sleep(0u); };
-  expectRealtimeDeath(func, "sleep");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "sleep");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, usleepDiesWhenRealtime) {
   auto func = []() { usleep(1u); };
-  expectRealtimeDeath(func, "usleep");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "usleep");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, nanosleepDiesWhenRealtime) {
@@ -157,8 +157,8 @@ TEST(TestRadsanInterceptors, nanosleepDiesWhenRealtime) {
     auto t = timespec{};
     nanosleep(&t, &t);
   };
-  expectRealtimeDeath(func, "nanosleep");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "nanosleep");
+  ExpectNonRealtimeSurvival(func);
 }
 
 /*
@@ -167,35 +167,35 @@ TEST(TestRadsanInterceptors, nanosleepDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, openDiesWhenRealtime) {
   auto func = []() { open(temporary_file_path(), O_RDONLY); };
-  expectRealtimeDeath(func, "open");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "open");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
 TEST(TestRadsanInterceptors, openatDiesWhenRealtime) {
   auto func = []() { openat(0, temporary_file_path(), O_RDONLY); };
-  expectRealtimeDeath(func, "openat");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "openat");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
 TEST(TestRadsanInterceptors, creatDiesWhenRealtime) {
   auto func = []() { creat(temporary_file_path(), S_IWOTH | S_IROTH); };
-  expectRealtimeDeath(func, "creat");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "creat");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
 TEST(TestRadsanInterceptors, fcntlDiesWhenRealtime) {
   auto func = []() { fcntl(0, F_GETFL); };
-  expectRealtimeDeath(func, "fcntl");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "fcntl");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, closeDiesWhenRealtime) {
   auto func = []() { close(0); };
-  expectRealtimeDeath(func, "close");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "close");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, fopenDiesWhenRealtime) {
@@ -203,8 +203,8 @@ TEST(TestRadsanInterceptors, fopenDiesWhenRealtime) {
     auto fd = fopen(temporary_file_path(), "w");
     EXPECT_THAT(fd, Ne(nullptr));
   };
-  expectRealtimeDeath(func, "fopen");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "fopen");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
@@ -214,8 +214,8 @@ TEST(TestRadsanInterceptors, freadDiesWhenRealtime) {
     char c{};
     fread(&c, 1, 1, fd);
   };
-  expectRealtimeDeath(func, "fread");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "fread");
+  ExpectNonRealtimeSurvival(func);
   if (fd != nullptr)
     fclose(fd);
   std::remove(temporary_file_path());
@@ -226,8 +226,8 @@ TEST(TestRadsanInterceptors, fwriteDiesWhenRealtime) {
   ASSERT_NE(nullptr, fd);
   auto message = "Hello, world!";
   auto func = [&]() { fwrite(&message, 1, 4, fd); };
-  expectRealtimeDeath(func, "fwrite");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "fwrite");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
@@ -235,23 +235,23 @@ TEST(TestRadsanInterceptors, fcloseDiesWhenRealtime) {
   auto fd = fopen(temporary_file_path(), "w");
   EXPECT_THAT(fd, Ne(nullptr));
   auto func = [fd]() { fclose(fd); };
-  expectRealtimeDeath(func, "fclose");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "fclose");
+  ExpectNonRealtimeSurvival(func);
   std::remove(temporary_file_path());
 }
 
 TEST(TestRadsanInterceptors, putsDiesWhenRealtime) {
   auto func = []() { puts("Hello, world!\n"); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func);
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, fputsDiesWhenRealtime) {
   auto fd = fopen(temporary_file_path(), "w");
   ASSERT_THAT(fd, Ne(nullptr)) << errno;
   auto func = [fd]() { fputs("Hello, world!\n", fd); };
-  expectRealtimeDeath(func);
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func);
+  ExpectNonRealtimeSurvival(func);
   if (fd != nullptr)
     fclose(fd);
   std::remove(temporary_file_path());
@@ -268,8 +268,8 @@ TEST(TestRadsanInterceptors, pthreadCreateDiesWhenRealtime) {
     struct thread_info *tinfo;
     pthread_create(&thread, &attr, &fake_thread_entry_point, tinfo);
   };
-  expectRealtimeDeath(func, "pthread_create");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_create");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadMutexLockDiesWhenRealtime) {
@@ -278,8 +278,8 @@ TEST(TestRadsanInterceptors, pthreadMutexLockDiesWhenRealtime) {
     pthread_mutex_lock(&mutex);
   };
 
-  expectRealtimeDeath(func, "pthread_mutex_lock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_mutex_lock");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadMutexUnlockDiesWhenRealtime) {
@@ -288,8 +288,8 @@ TEST(TestRadsanInterceptors, pthreadMutexUnlockDiesWhenRealtime) {
     pthread_mutex_unlock(&mutex);
   };
 
-  expectRealtimeDeath(func, "pthread_mutex_unlock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_mutex_unlock");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadMutexJoinDiesWhenRealtime) {
@@ -298,8 +298,8 @@ TEST(TestRadsanInterceptors, pthreadMutexJoinDiesWhenRealtime) {
     pthread_join(thread, nullptr);
   };
 
-  expectRealtimeDeath(func, "pthread_join");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_join");
+  ExpectNonRealtimeSurvival(func);
 }
 
 #if SANITIZER_APPLE
@@ -312,8 +312,8 @@ TEST(TestRadsanInterceptors, osSpinLockLockDiesWhenRealtime) {
     auto spin_lock = OSSpinLock{};
     OSSpinLockLock(&spin_lock);
   };
-  expectRealtimeDeath(func, "OSSpinLockLock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "OSSpinLockLock");
+  ExpectNonRealtimeSurvival(func);
 }
 #pragma clang diagnostic pop
 
@@ -322,8 +322,8 @@ TEST(TestRadsanInterceptors, osUnfairLockLockDiesWhenRealtime) {
     auto unfair_lock = os_unfair_lock_s{};
     os_unfair_lock_lock(&unfair_lock);
   };
-  expectRealtimeDeath(func, "os_unfair_lock_lock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "os_unfair_lock_lock");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
@@ -332,8 +332,8 @@ TEST(TestRadsanInterceptors, spinLockLockDiesWhenRealtime) {
   auto spinlock = pthread_spinlock_t{};
   pthread_spin_init(&spinlock, PTHREAD_PROCESS_SHARED);
   auto func = [&]() { pthread_spin_lock(&spinlock); };
-  expectRealtimeDeath(func, "pthread_spin_lock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_spin_lock");
+  ExpectNonRealtimeSurvival(func);
 }
 #endif
 
@@ -342,8 +342,8 @@ TEST(TestRadsanInterceptors, pthreadCondSignalDiesWhenRealtime) {
     auto cond = pthread_cond_t{};
     pthread_cond_signal(&cond);
   };
-  expectRealtimeDeath(func, "pthread_cond_signal");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_cond_signal");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadCondBroadcastDiesWhenRealtime) {
@@ -351,8 +351,8 @@ TEST(TestRadsanInterceptors, pthreadCondBroadcastDiesWhenRealtime) {
     auto cond = pthread_cond_t{};
     pthread_cond_broadcast(&cond);
   };
-  expectRealtimeDeath(func, "pthread_cond_broadcast");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_cond_broadcast");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadCondWaitDiesWhenRealtime) {
@@ -361,7 +361,7 @@ TEST(TestRadsanInterceptors, pthreadCondWaitDiesWhenRealtime) {
   ASSERT_EQ(0, pthread_cond_init(&cond, nullptr));
   ASSERT_EQ(0, pthread_mutex_init(&mutex, nullptr));
   auto func = [&]() { pthread_cond_wait(&cond, &mutex); };
-  expectRealtimeDeath(func, "pthread_cond_wait");
+  ExpectRealtimeDeath(func, "pthread_cond_wait");
   // It's very difficult to test the success case here without doing some
   // sleeping, which is at the mercy of the scheduler. What's really important
   // here is the interception - so we're only testing that for now.
@@ -372,8 +372,8 @@ TEST(TestRadsanInterceptors, pthreadRwlockRdlockDiesWhenRealtime) {
     auto rwlock = pthread_rwlock_t{};
     pthread_rwlock_rdlock(&rwlock);
   };
-  expectRealtimeDeath(func, "pthread_rwlock_rdlock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_rwlock_rdlock");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadRwlockUnlockDiesWhenRealtime) {
@@ -381,8 +381,8 @@ TEST(TestRadsanInterceptors, pthreadRwlockUnlockDiesWhenRealtime) {
     auto rwlock = pthread_rwlock_t{};
     pthread_rwlock_unlock(&rwlock);
   };
-  expectRealtimeDeath(func, "pthread_rwlock_unlock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_rwlock_unlock");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, pthreadRwlockWrlockDiesWhenRealtime) {
@@ -390,8 +390,8 @@ TEST(TestRadsanInterceptors, pthreadRwlockWrlockDiesWhenRealtime) {
     auto rwlock = pthread_rwlock_t{};
     pthread_rwlock_wrlock(&rwlock);
   };
-  expectRealtimeDeath(func, "pthread_rwlock_wrlock");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "pthread_rwlock_wrlock");
+  ExpectNonRealtimeSurvival(func);
 }
 
 /*
@@ -399,54 +399,54 @@ TEST(TestRadsanInterceptors, pthreadRwlockWrlockDiesWhenRealtime) {
 */
 TEST(TestRadsanInterceptors, openingASocketDiesWhenRealtime) {
   auto func = []() { socket(PF_INET, SOCK_STREAM, 0); };
-  expectRealtimeDeath(func, "socket");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "socket");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, sendToASocketDiesWhenRealtime) {
   auto func = []() { send(0, nullptr, 0, 0); };
-  expectRealtimeDeath(func, "send");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "send");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, sendmsgToASocketDiesWhenRealtime) {
   auto const msg = msghdr{};
   auto func = [&]() { sendmsg(0, &msg, 0); };
-  expectRealtimeDeath(func, "sendmsg");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "sendmsg");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, sendtoToASocketDiesWhenRealtime) {
   auto const addr = sockaddr{};
   auto const len = socklen_t{};
   auto func = [&]() { sendto(0, nullptr, 0, 0, &addr, len); };
-  expectRealtimeDeath(func, "sendto");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "sendto");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, recvFromASocketDiesWhenRealtime) {
   auto func = []() { recv(0, nullptr, 0, 0); };
-  expectRealtimeDeath(func, "recv");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "recv");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, recvfromOnASocketDiesWhenRealtime) {
   auto addr = sockaddr{};
   auto len = socklen_t{};
   auto func = [&]() { recvfrom(0, nullptr, 0, 0, &addr, &len); };
-  expectRealtimeDeath(func, "recvfrom");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "recvfrom");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, recvmsgOnASocketDiesWhenRealtime) {
   auto msg = msghdr{};
   auto func = [&]() { recvmsg(0, &msg, 0); };
-  expectRealtimeDeath(func, "recvmsg");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "recvmsg");
+  ExpectNonRealtimeSurvival(func);
 }
 
 TEST(TestRadsanInterceptors, shutdownOnASocketDiesWhenRealtime) {
   auto func = [&]() { shutdown(0, 0); };
-  expectRealtimeDeath(func, "shutdown");
-  expectNonrealtimeSurvival(func);
+  ExpectRealtimeDeath(func, "shutdown");
+  ExpectNonRealtimeSurvival(func);
 }

--- a/compiler-rt/lib/radsan/tests/radsan_test_utilities.h
+++ b/compiler-rt/lib/radsan/tests/radsan_test_utilities.h
@@ -19,7 +19,7 @@ template <typename Function>
 }
 
 template <typename Function>
-void expectRealtimeDeath(Function &&func,
+void ExpectRealtimeDeath(Function &&func,
                          const char *intercepted_method_name = nullptr) {
 
   using namespace testing;
@@ -36,7 +36,7 @@ void expectRealtimeDeath(Function &&func,
               ExitedWithCode(EXIT_FAILURE), expected_error_substr());
 }
 
-template <typename Function> void expectNonrealtimeSurvival(Function &&func) {
+template <typename Function> void ExpectNonRealtimeSurvival(Function &&func) {
   std::forward<Function>(func)();
 }
 

--- a/compiler-rt/lib/radsan/tests/radsan_test_utilities.h
+++ b/compiler-rt/lib/radsan/tests/radsan_test_utilities.h
@@ -14,17 +14,20 @@
 namespace radsan_testing {
 
 template <typename Function>
-[[clang::realtime]] void realtimeInvoke(Function &&func) {
-  std::forward<Function>(func)();
+void RealtimeInvoke(Function &&Func)
+{
+  radsan_realtime_enter();
+  std::forward<Function>(Func)();
+  radsan_realtime_exit();
 }
 
 template <typename Function>
-void ExpectRealtimeDeath(Function &&func,
+void ExpectRealtimeDeath(Function &&Func,
                          const char *intercepted_method_name = nullptr) {
 
   using namespace testing;
 
-  auto expected_error_substr = [&]() -> std::string {
+  auto ExpectedErrorSubstring = [&]() -> std::string {
     return intercepted_method_name != nullptr
                ? "Real-time violation: intercepted call to real-time unsafe "
                  "function `" +
@@ -32,12 +35,12 @@ void ExpectRealtimeDeath(Function &&func,
                : "";
   };
 
-  EXPECT_EXIT(realtimeInvoke(std::forward<Function>(func)),
-              ExitedWithCode(EXIT_FAILURE), expected_error_substr());
+  EXPECT_EXIT(RealtimeInvoke(std::forward<Function>(Func)),
+              ExitedWithCode(EXIT_FAILURE), ExpectedErrorSubstring());
 }
 
-template <typename Function> void ExpectNonRealtimeSurvival(Function &&func) {
-  std::forward<Function>(func)();
+template <typename Function> void ExpectNonRealtimeSurvival(Function &&Func) {
+  std::forward<Function>(Func)();
 }
 
 } // namespace radsan_testing


### PR DESCRIPTION
Generally, this included:

* Moving to LLVM style license statements
* Moving to UpperCamelCase from lowerCamelCase
* Removing `auto` almost everywhere (except lambdas, where they are accepted)
* Americanizing names (sorry David :( ) initialise->initialize to match other santisers (whoops, sanitizers)
* Get rid of `RADSAN_EXPORT` as they already have one defined as `SANITIZER_INTERFACE_ATTRIBUTE`
