### PR TITLE
Fix issue where CREAT flag was not properly passing mode

### DIFF
--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -51,10 +51,13 @@ INTERCEPTOR(int, open, const char *path, int oflag, ...) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
   radsan::expectNotRealtime("open");
+
   va_list args;
   va_start(args, oflag);
-  auto result = REAL(open)(path, oflag, args);
+  const mode_t mode = va_arg(args, int);
   va_end(args);
+
+  const int result = REAL(open)(path, oflag, mode);
   return result;
 }
 
@@ -62,10 +65,13 @@ INTERCEPTOR(int, openat, int fd, const char *path, int oflag, ...) {
   // TODO Establish whether we should intercept here if the flag contains
   // O_NONBLOCK
   radsan::expectNotRealtime("openat");
+
   va_list args;
   va_start(args, oflag);
-  auto result = REAL(openat)(fd, path, oflag, args);
+  mode_t mode = va_arg(args, int);
   va_end(args);
+
+  const int result = REAL(openat)(fd, path, oflag, mode);
   return result;
 }
 

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -85,11 +85,13 @@ INTERCEPTOR(int, creat, const char *path, mode_t mode) {
 
 INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
   radsan::expectNotRealtime("fcntl");
+
   va_list args;
   va_start(args, cmd);
-  auto result = REAL(fcntl)(filedes, cmd, args);
+  void *arg = va_arg(args, void *);
   va_end(args);
-  return result;
+
+  return fcntl(filedes, cmd, arg);
 }
 
 INTERCEPTOR(int, close, int filedes) {

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -181,7 +181,6 @@ TEST(TestRadsanInterceptors, openatDiesWhenRealtime) {
 
 TEST(TestRadsanInterceptors, openCreatesFileWithProperMode) {
   const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
-  ASSERT_THAT(mode, Eq(0644));
 
   const int fd = open(temporary_file_path(), O_CREAT | O_WRONLY, mode);
   ASSERT_THAT(fd, Ne(-1));
@@ -190,7 +189,7 @@ TEST(TestRadsanInterceptors, openCreatesFileWithProperMode) {
   struct stat st;
   ASSERT_THAT(stat(temporary_file_path(), &st), Eq(0));
 
-  // Mask st_mode with 07777 to get permission bits only
+  // Mask st_mode to get permission bits only
   ASSERT_THAT(st.st_mode & 0777, Eq(mode));
 
   std::remove(temporary_file_path());

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -179,6 +179,23 @@ TEST(TestRadsanInterceptors, openatDiesWhenRealtime) {
   std::remove(temporary_file_path());
 }
 
+TEST(TestRadsanInterceptors, openCreatesFileWithProperMode) {
+  const int mode = S_IRGRP | S_IROTH | S_IRUSR | S_IWUSR;
+  ASSERT_THAT(mode, Eq(0644));
+
+  const int fd = open(temporary_file_path(), O_CREAT | O_WRONLY, mode);
+  ASSERT_THAT(fd, Ne(-1));
+  close(fd);
+
+  struct stat st;
+  ASSERT_THAT(stat(temporary_file_path(), &st), Eq(0));
+
+  // Mask st_mode with 07777 to get permission bits only
+  ASSERT_THAT(st.st_mode & 0777, Eq(mode));
+
+  std::remove(temporary_file_path());
+}
+
 TEST(TestRadsanInterceptors, creatDiesWhenRealtime) {
   auto func = []() { creat(temporary_file_path(), S_IWOTH | S_IROTH); };
   expectRealtimeDeath(func, "creat");


### PR DESCRIPTION
Fixes https://github.com/realtime-sanitizer/radsan/issues/31 

**NOTE, THIS PR IS MERGING INTO radsan-upstream-v0** Once approved let's cherry pick it to the first upstream PR and the radsan branch 

This issue came about only when the CREAT flag is passed, this means that there is an extra va_args argument that needs to be extracted. From the docs:

```
$ man 2 open
The oflag argument may indicate that the file is to be created if it does not exist (by specifying the O_CREAT flag).  In this case, open() and
     openat() require an additional argument mode_t mode; the file is created with mode mode as described in chmod(2) and modified by the process' umask
     value (see umask(2)).
```

We were passing the va_args down to the call, but in typical fashion va_args tends to explode in unexpected ways when you pass them down the call stack to a new function.

To fix this, I unpacked them directly then passed them in. This follows known prior art as it's the pattern tsan follows here:

https://github.com/llvm/llvm-project/blob/435ea21c897f94b5a3777a9f152e4c5bb4a371a3/compiler-rt/lib/tsan/rtl/tsan_interceptors_posix.cpp#L1656


This unit test fails on the old version of the interceptor, but passes now! :)