### PR TITLE
Fix issue where fcntl was not using last arg correctly

### DIFF
--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -89,9 +89,13 @@ INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
   va_list args;
   va_start(args, cmd);
 
-  // bit of a hack here, we need to throw the argument into a variable that will
-  // hold the largest of the possible argument types. It is then assumed that
-  // fcntl will cast it properly.
+  // Following precedent here. The linux source (fcntl.c, do_fcntl) accepts the
+  // final argument in a variable that will hold the largest of the possible
+  // argument types (pointers and ints are typical in fcntl) It is then assumed
+  // that the implementation of fcntl will cast it properly depending on cmd.
+  //
+  // This is also similar to what is done in
+  // sanitizer_common/sanitizer_common_syscalls.inc
   const unsigned long arg = va_arg(args, unsigned long);
   int result = REAL(fcntl)(filedes, cmd, arg);
 

--- a/compiler-rt/lib/radsan/radsan_interceptors.cpp
+++ b/compiler-rt/lib/radsan/radsan_interceptors.cpp
@@ -88,10 +88,16 @@ INTERCEPTOR(int, fcntl, int filedes, int cmd, ...) {
 
   va_list args;
   va_start(args, cmd);
-  void *arg = va_arg(args, void *);
+
+  // bit of a hack here, we need to throw the argument into a variable that will
+  // hold the largest of the possible argument types. It is then assumed that
+  // fcntl will cast it properly.
+  const unsigned long arg = va_arg(args, unsigned long);
+  int result = REAL(fcntl)(filedes, cmd, arg);
+
   va_end(args);
 
-  return fcntl(filedes, cmd, arg);
+  return result;
 }
 
 INTERCEPTOR(int, close, int filedes) {

--- a/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
+++ b/compiler-rt/lib/radsan/tests/radsan_test_interceptors.cpp
@@ -213,11 +213,11 @@ TEST(TestRadsanInterceptors, fcntlFlockDiesWhenRealtime) {
   ASSERT_THAT(fd, Ne(-1));
 
   auto func = [fd]() {
-    struct flock lock{};
+    struct flock lock {};
     lock.l_type = F_RDLCK;
     lock.l_whence = SEEK_SET;
     lock.l_start = 0;
-    lock.l_len = 0; 
+    lock.l_len = 0;
     lock.l_pid = ::getpid();
 
     ASSERT_THAT(fcntl(fd, F_GETLK, &lock), Eq(0));
@@ -228,6 +228,28 @@ TEST(TestRadsanInterceptors, fcntlFlockDiesWhenRealtime) {
 
   close(fd);
   std::remove(temporary_file_path());
+}
+
+TEST(TestRadsanInterceptors, fcntlSetFdDiesWhenRealtime) {
+  int fd = creat(temporary_file_path(), S_IRUSR | S_IWUSR);
+  ASSERT_THAT(fd, Ne(-1));
+
+  auto func = [fd]() {
+    int old_flags = fcntl(fd, F_GETFD);
+    ASSERT_THAT(fcntl(fd, F_SETFD, FD_CLOEXEC), Eq(0));
+
+    int flags = fcntl(fd, F_GETFD);
+    ASSERT_THAT(flags, Ne(-1));
+    ASSERT_THAT(flags & FD_CLOEXEC, Eq(FD_CLOEXEC));
+
+    ASSERT_THAT(fcntl(fd, F_SETFD, old_flags), Eq(0));
+    ASSERT_THAT(fcntl(fd, F_GETFD), Eq(old_flags));
+  };
+
+  expectRealtimeDeath(func, "fcntl");
+  expectNonrealtimeSurvival(func);
+
+  close(fd);
 }
 
 TEST(TestRadsanInterceptors, closeDiesWhenRealtime) {


### PR DESCRIPTION
The main issue is that there are at least 3 different types of variable that the last variable can be in `fcntl`. What's worse is that the availability of different `cmd` varies by platform and platform version. We have to have some parity with those expected arguments, which would imply some kind of nasty switch statement.

It appears from the linux [source code ](https://github.com/torvalds/linux/blob/master/fs/fcntl.c#L346) that the underlying fcntl object expects an unsigned long, then casts it to be the right type. There is other evidence of this in the llvm repo, such as:

```
lib/sanitizer_common/sanitizer_common_syscalls.inc
1323:PRE_SYSCALL(fcntl)(long fd, long cmd, long arg) {}
1325:POST_SYSCALL(fcntl)(long res, long fd, long cmd, long arg) {}
1327:PRE_SYSCALL(fcntl64)(long fd, long cmd, long arg) {}
1329:POST_SYSCALL(fcntl64)(long res, long fd, long cmd, long arg) {}
```


Where it appears the idea is similar, "throw the arg in a `long`, it has enough space, and it will be casted later"